### PR TITLE
Include MARC example records

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,5 @@
+The MARCXML files in this directory include examples given in appendic B of MARC 21 Classification format specification:
+
+* [class 003](https://www.loc.gov/marc/classification/examples.html#ddc003): `ddc21en-003.*.xml`
+* [table 6](https://www.loc.gov/marc/classification/examples.html#ddc6): `ddc21en-6--*.xml`
+

--- a/examples/ddc21en-003.3.xml
+++ b/examples/ddc21en-003.3.xml
@@ -1,0 +1,101 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<marc:collection xmlns:marc="http://www.loc.gov/MARC21/slim">
+   <marc:record>
+      <marc:leader>*****nw###22*****n##4500</marc:leader>
+      <marc:datafield tag="084" ind1="0" ind2="#">
+         <marc:subfield code="a">ddc</marc:subfield>
+         <marc:subfield code="c">21</marc:subfield>
+      </marc:datafield>
+      <marc:datafield tag="153" ind1=" " ind2=" ">
+         <marc:subfield code="a">003.3</marc:subfield>
+         <marc:subfield code="h">Generalities</marc:subfield>
+         <marc:subfield code="h">Systems</marc:subfield>
+         <marc:subfield code="j">Computer modeling and simulation</marc:subfield>
+      </marc:datafield>
+      <marc:datafield tag="253" ind1="2" ind2="#">
+         <marc:subfield code="i">For computer modeling and simulation applied to a specific subject, see the subject plus notation</marc:subfield>
+         <marc:subfield code="z">1</marc:subfield>
+         <marc:subfield code="a">0113</marc:subfield>
+         <marc:subfield code="i">from Table 1, e.g., computer modeling in economics</marc:subfield>
+         <marc:subfield code="a">330.0113</marc:subfield>
+      </marc:datafield>
+      <marc:datafield tag="453" ind1="0" ind2="#">
+         <marc:subfield code="w">m</marc:subfield>
+         <marc:subfield code="a">003.0285</marc:subfield>
+         <marc:subfield code="h">Generalities</marc:subfield>
+         <marc:subfield code="h">Systems</marc:subfield>
+         <marc:subfield code="h">Miscellany</marc:subfield>
+         <marc:subfield code="h">Auxiliary techniques and procedures; apparatus, equipment, materials</marc:subfield>
+         <marc:subfield code="k">Auxiliary techniques and procedures</marc:subfield>
+         <marc:subfield code="j">Data processing. Computer applications</marc:subfield>
+      </marc:datafield>
+      <marc:datafield tag="553" ind1="0" ind2="#">
+         <marc:subfield code="w">k</marc:subfield>
+         <marc:subfield code="a">001.42</marc:subfield>
+         <marc:subfield code="h">Generalities</marc:subfield>
+         <marc:subfield code="h">Knowledge</marc:subfield>
+         <marc:subfield code="h">Research; statistical methods</marc:subfield>
+         <marc:subfield code="j">Research methods</marc:subfield>
+         <marc:subfield code="t">computer modeling and simulation</marc:subfield>
+      </marc:datafield>
+      <marc:datafield tag="553" ind1="0" ind2="#">
+         <marc:subfield code="w">k</marc:subfield>
+         <marc:subfield code="a">004</marc:subfield>
+         <marc:subfield code="h">Generalities</marc:subfield>
+         <marc:subfield code="j">Data processing. Computer science</marc:subfield>
+         <marc:subfield code="t">computer modeling and simulation</marc:subfield>
+      </marc:datafield>
+      <marc:datafield tag="680" ind1="1" ind2="#">
+         <marc:subfield code="i">Class here data processing and computer science applied to systems, computer implementation of mathematical models of systems, interdisciplinary works on computer modeling and simulation</marc:subfield>
+      </marc:datafield>
+      <marc:datafield tag="684" ind1="0" ind2="#">
+         <marc:subfield code="z">1</marc:subfield>
+         <marc:subfield code="a">0285</marc:subfield>
+         <marc:subfield code="i">vs.</marc:subfield>
+         <marc:subfield code="z">1</marc:subfield>
+         <marc:subfield code="a">0113</marc:subfield>
+         <marc:subfield code="j">Data processing. Computer applications vs. [Computer modeling and simulation]</marc:subfield>
+      </marc:datafield>
+      <marc:datafield tag="685" ind1="0" ind2="3">
+         <marc:subfield code="t">Computer modeling and simulation</marc:subfield>
+         <marc:subfield code="b">003</marc:subfield>
+         <marc:subfield code="d">19890306</marc:subfield>
+         <marc:subfield code="2">20</marc:subfield>
+      </marc:datafield>
+      <marc:datafield tag="753" ind1=" " ind2=" ">
+         <marc:subfield code="a">Computer modeling</marc:subfield>
+      </marc:datafield>
+      <marc:datafield tag="753" ind1=" " ind2=" ">
+         <marc:subfield code="a">Computer simulation</marc:subfield>
+      </marc:datafield>
+      <marc:datafield tag="761" ind1=" " ind2=" ">
+         <marc:subfield code="i">Standard subdivisions are added for either or both topics in heading</marc:subfield>
+      </marc:datafield>
+      <marc:datafield tag="761" ind1=" " ind2=" ">
+         <marc:subfield code="i">Add to base number</marc:subfield>
+         <marc:subfield code="b">003.3</marc:subfield>
+         <marc:subfield code="i">the numbers following</marc:subfield>
+         <marc:subfield code="r">00</marc:subfield>
+         <marc:subfield code="i">in</marc:subfield>
+         <marc:subfield code="d">004</marc:subfield>
+         <marc:subfield code="c">006,</marc:subfield>
+         <marc:subfield code="i">e.g., computer simulation languages</marc:subfield>
+         <marc:subfield code="e">003.3513</marc:subfield>
+      </marc:datafield>
+      <marc:datafield tag="765" ind1="1" ind2="#">
+         <marc:subfield code="b">003.3</marc:subfield>
+         <marc:subfield code="a">003.3</marc:subfield>
+         <marc:subfield code="r">00</marc:subfield>
+         <marc:subfield code="s">513</marc:subfield>
+         <marc:subfield code="u">003.3513</marc:subfield>
+      </marc:datafield>
+      <marc:datafield tag="765" ind1="1" ind2="#">
+         <marc:subfield code="b">003</marc:subfield>
+         <marc:subfield code="z">1</marc:subfield>
+         <marc:subfield code="a">0</marc:subfield>
+         <marc:subfield code="z">1</marc:subfield>
+         <marc:subfield code="s">0285</marc:subfield>
+         <marc:subfield code="u">003.0285</marc:subfield>
+      </marc:datafield>
+   </marc:record>
+</marc:collection>

--- a/examples/ddc21en-003.5.xml
+++ b/examples/ddc21en-003.5.xml
@@ -1,0 +1,141 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<marc:collection xmlns:marc="http://www.loc.gov/MARC21/slim">
+   <marc:record>
+      <marc:leader>*****nw###22*****n##4500</marc:leader>
+      <marc:datafield tag="084" ind1="0" ind2="#">
+         <marc:subfield code="a">ddc</marc:subfield>
+         <marc:subfield code="c">21</marc:subfield>
+      </marc:datafield>
+      <marc:datafield tag="253" ind1="2" ind2="#">
+         <marc:subfield code="i">For control and stability of systems in a specific subject, see the subject plus notation</marc:subfield>
+         <marc:subfield code="z">1</marc:subfield>
+         <marc:subfield code="a">0115</marc:subfield>
+         <marc:subfield code="i">from Table 1, e.g., control and stability of systems in general engineering</marc:subfield>
+         <marc:subfield code="a">620.00115</marc:subfield>
+      </marc:datafield>
+      <marc:datafield tag="153" ind1=" " ind2=" ">
+         <marc:subfield code="a">003.5</marc:subfield>
+         <marc:subfield code="h">Generalities</marc:subfield>
+         <marc:subfield code="h">Systems</marc:subfield>
+         <marc:subfield code="j">Theory of communication and control</marc:subfield>
+      </marc:datafield>
+      <marc:datafield tag="553" ind1="0" ind2="#">
+         <marc:subfield code="w">kh</marc:subfield>
+         <marc:subfield code="a">515.64</marc:subfield>
+         <marc:subfield code="h">Natural sciences and mathematics</marc:subfield>
+         <marc:subfield code="h">Mathematics</marc:subfield>
+         <marc:subfield code="h">Analysis</marc:subfield>
+         <marc:subfield code="h">Other analytic methods</marc:subfield>
+         <marc:subfield code="j">Calculus of variations</marc:subfield>
+         <marc:subfield code="t">interdisciplinary works on control theory</marc:subfield>
+      </marc:datafield>
+      <marc:datafield tag="553" ind1="0" ind2="#">
+         <marc:subfield code="w">kh</marc:subfield>
+         <marc:subfield code="a">629.8312</marc:subfield>
+         <marc:subfield code="h">Technology (Applied sciences)</marc:subfield>
+         <marc:subfield code="h">Engineering and allied operations</marc:subfield>
+         <marc:subfield code="h">Other branches of engineering</marc:subfield>
+         <marc:subfield code="h">Automatic control engineering</marc:subfield>
+         <marc:subfield code="h">Closed-loop (Feedback) systems</marc:subfield>
+         <marc:subfield code="h">General principles</marc:subfield>
+         <marc:subfield code="j">Control theory</marc:subfield>
+         <marc:subfield code="t">interdisciplinary works on control theory</marc:subfield>
+      </marc:datafield>
+      <marc:datafield tag="680" ind1="1" ind2="#">
+         <marc:subfield code="i">In living and nonliving systems</marc:subfield>
+      </marc:datafield>
+      <marc:datafield tag="680" ind1="0" ind2="#">
+         <marc:subfield code="i">Including bionics</marc:subfield>
+      </marc:datafield>
+      <marc:datafield tag="680" ind1="1" ind2="#">
+         <marc:subfield code="i">Class here cybernetics, interdisciplinary works on the control and stability of systems</marc:subfield>
+      </marc:datafield>
+      <marc:datafield tag="684" ind1="0" ind2="#">
+         <marc:subfield code="a">003.5</marc:subfield>
+         <marc:subfield code="i">vs.</marc:subfield>
+         <marc:subfield code="a">629.8</marc:subfield>
+         <marc:subfield code="j">Theory of communication and control vs. Automatic control engineering</marc:subfield>
+      </marc:datafield>
+      <marc:datafield tag="684" ind1="1" ind2="#">
+         <marc:subfield code="i">Class interdisciplinary works on control of living and nonliving systems in</marc:subfield>
+         <marc:subfield code="a">003.5</marc:subfield>
+         <marc:subfield code="i">or with various specific kinds of systems in</marc:subfield>
+         <marc:subfield code="a">003.7</marc:subfield>
+         <marc:subfield code="c">003.8.</marc:subfield>
+         <marc:subfield code="i">Class automatic control of man-made physical systems in</marc:subfield>
+         <marc:subfield code="a">629.8.</marc:subfield>
+         <marc:subfield code="i">If in doubt, prefer</marc:subfield>
+         <marc:subfield code="a">003.5.</marc:subfield>
+      </marc:datafield>
+      <marc:datafield tag="685" ind1="0" ind2="3">
+         <marc:subfield code="t">Theory of communication and control</marc:subfield>
+         <marc:subfield code="b">003</marc:subfield>
+         <marc:subfield code="d">19890306</marc:subfield>
+         <marc:subfield code="2">20</marc:subfield>
+      </marc:datafield>
+      <marc:datafield tag="685" ind1="0" ind2="0">
+         <marc:subfield code="t">Cybernetics</marc:subfield>
+         <marc:subfield code="i">formerly located in</marc:subfield>
+         <marc:subfield code="b">001.53</marc:subfield>
+         <marc:subfield code="d">19890306</marc:subfield>
+         <marc:subfield code="2">20</marc:subfield>
+      </marc:datafield>
+      <marc:datafield tag="753" ind1=" " ind2=" ">
+         <marc:subfield code="a">Control theory</marc:subfield>
+      </marc:datafield>
+      <marc:datafield tag="753" ind1=" " ind2=" ">
+         <marc:subfield code="a">Control theory</marc:subfield>
+         <marc:subfield code="b">systems</marc:subfield>
+      </marc:datafield>
+      <marc:datafield tag="753" ind1=" " ind2=" ">
+         <marc:subfield code="a">Bionics</marc:subfield>
+      </marc:datafield>
+      <marc:datafield tag="753" ind1=" " ind2=" ">
+         <marc:subfield code="a">Cybernetics</marc:subfield>
+      </marc:datafield>
+      <marc:datafield tag="753" ind1=" " ind2=" ">
+         <marc:subfield code="a">Process control</marc:subfield>
+      </marc:datafield>
+      <marc:datafield tag="753" ind1=" " ind2=" ">
+         <marc:subfield code="a">Systems control</marc:subfield>
+      </marc:datafield>
+      <marc:datafield tag="753" ind1=" " ind2=" ">
+         <marc:subfield code="a">Systems stability</marc:subfield>
+      </marc:datafield>
+   </marc:record>
+   <marc:record>
+      <marc:leader>*****nw###22*****n##4500</marc:leader>
+      <marc:datafield tag="153" ind1=" " ind2=" ">
+         <marc:subfield code="a">302.2</marc:subfield>
+         <marc:subfield code="h">Social sciences</marc:subfield>
+         <marc:subfield code="k">Specific topics in sociology and anthropology</marc:subfield>
+         <marc:subfield code="h">Social interaction</marc:subfield>
+         <marc:subfield code="j">Communication</marc:subfield>
+      </marc:datafield>
+      <marc:datafield tag="553" ind1="0" ind2="#">
+         <marc:subfield code="w">kh</marc:subfield>
+         <marc:subfield code="a">003.5</marc:subfield>
+         <marc:subfield code="h">Generalities</marc:subfield>
+         <marc:subfield code="h">Systems</marc:subfield>
+         <marc:subfield code="j">Theory of communication and control</marc:subfield>
+         <marc:subfield code="t">social aspects of and interdisciplinary works on communication in systems</marc:subfield>
+      </marc:datafield>
+   </marc:record>
+   <marc:record>
+      <marc:leader>*****nw###22*****n##4500</marc:leader>
+      <marc:datafield tag="153" ind1=" " ind2=" ">
+         <marc:subfield code="a">006.3</marc:subfield>
+         <marc:subfield code="h">Generalities</marc:subfield>
+         <marc:subfield code="h">Special computer methods</marc:subfield>
+         <marc:subfield code="j">Artificial intelligence</marc:subfield>
+      </marc:datafield>
+      <marc:datafield tag="553" ind1="0" ind2="#">
+         <marc:subfield code="w">jg</marc:subfield>
+         <marc:subfield code="a">003.5</marc:subfield>
+         <marc:subfield code="h">Generalities</marc:subfield>
+         <marc:subfield code="h">Systems</marc:subfield>
+         <marc:subfield code="j">Theory of communication and control</marc:subfield>
+         <marc:subfield code="t">artificial intelligence</marc:subfield>
+      </marc:datafield>
+   </marc:record>
+</marc:collection>

--- a/examples/ddc21en-003.52.xml
+++ b/examples/ddc21en-003.52.xml
@@ -1,0 +1,106 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<marc:collection xmlns:marc="http://www.loc.gov/MARC21/slim">
+   <marc:record>
+      <marc:leader>*****nw###22*****n##4500</marc:leader>
+      <marc:datafield tag="084" ind1="0" ind2="#">
+         <marc:subfield code="a">ddc</marc:subfield>
+         <marc:subfield code="c">21</marc:subfield>
+      </marc:datafield>
+      <marc:datafield tag="153" ind1=" " ind2=" ">
+         <marc:subfield code="a">003.52</marc:subfield>
+         <marc:subfield code="h">Generalities</marc:subfield>
+         <marc:subfield code="h">Systems</marc:subfield>
+         <marc:subfield code="h">Theory of communication and control</marc:subfield>
+         <marc:subfield code="j">Perception theory</marc:subfield>
+      </marc:datafield>
+      <marc:datafield tag="685" ind1="0" ind2="0">
+         <marc:subfield code="t">Perception theory</marc:subfield>
+         <marc:subfield code="i">formerly located in</marc:subfield>
+         <marc:subfield code="b">001.534</marc:subfield>
+         <marc:subfield code="d">19890306</marc:subfield>
+         <marc:subfield code="2">20</marc:subfield>
+      </marc:datafield>
+      <marc:datafield tag="753" ind1=" " ind2=" ">
+         <marc:subfield code="a">Perception theory</marc:subfield>
+      </marc:datafield>
+   </marc:record>
+   <marc:record>
+      <marc:leader>*****nw###22*****n##4500</marc:leader>
+      <marc:datafield tag="153" ind1=" " ind2=" ">
+         <marc:subfield code="a">006.37</marc:subfield>
+         <marc:subfield code="h">Generalities</marc:subfield>
+         <marc:subfield code="h">Special computer methods</marc:subfield>
+         <marc:subfield code="h">Artificial intelligence</marc:subfield>
+         <marc:subfield code="j">Computer vision</marc:subfield>
+      </marc:datafield>
+      <marc:datafield tag="553" ind1="0" ind2="#">
+         <marc:subfield code="w">k</marc:subfield>
+         <marc:subfield code="a">003.52</marc:subfield>
+         <marc:subfield code="h">Generalities</marc:subfield>
+         <marc:subfield code="h">Systems</marc:subfield>
+         <marc:subfield code="h">Theory of communication and control</marc:subfield>
+         <marc:subfield code="j">Perception theory</marc:subfield>
+         <marc:subfield code="t">computer vision</marc:subfield>
+      </marc:datafield>
+   </marc:record>
+   <marc:record>
+      <marc:leader>*****nw###22*****n##4500</marc:leader>
+      <marc:datafield tag="153" ind1=" " ind2=" ">
+         <marc:subfield code="a">153.7</marc:subfield>
+         <marc:subfield code="h">Philosophy, paranormal phenomena, psychology</marc:subfield>
+         <marc:subfield code="h">Psychology</marc:subfield>
+         <marc:subfield code="k">Specific topics in psychology</marc:subfield>
+         <marc:subfield code="h">Conscious mental processes and intelligence</marc:subfield>
+         <marc:subfield code="j">Perceptual processes</marc:subfield>
+      </marc:datafield>
+      <marc:datafield tag="553" ind1="0" ind2="#">
+         <marc:subfield code="w">k</marc:subfield>
+         <marc:subfield code="a">003.52</marc:subfield>
+         <marc:subfield code="h">Generalities</marc:subfield>
+         <marc:subfield code="h">Systems</marc:subfield>
+         <marc:subfield code="h">Theory of communication and control</marc:subfield>
+         <marc:subfield code="j">Perception theory</marc:subfield>
+         <marc:subfield code="t">psychology of human perception</marc:subfield>
+      </marc:datafield>
+   </marc:record>
+   <marc:record>
+      <marc:leader>*****nw###22*****n##4500</marc:leader>
+      <marc:datafield tag="153" ind1=" " ind2=" ">
+         <marc:subfield code="a">573.87</marc:subfield>
+         <marc:subfield code="h">Natural sciences and mathematics</marc:subfield>
+         <marc:subfield code="k">Life sciences</marc:subfield>
+         <marc:subfield code="h">Life sciences. Biology</marc:subfield>
+         <marc:subfield code="k">Internal biological processes and structures</marc:subfield>
+         <marc:subfield code="h">Specific physiological systems in animals, regional histology and physiology</marc:subfield>
+         <marc:subfield code="h">Nervous and sensory systems</marc:subfield>
+         <marc:subfield code="j">Sense organs</marc:subfield>
+      </marc:datafield>
+      <marc:datafield tag="553" ind1="0" ind2="#">
+         <marc:subfield code="w">k</marc:subfield>
+         <marc:subfield code="a">003.52</marc:subfield>
+         <marc:subfield code="h">Generalities</marc:subfield>
+         <marc:subfield code="h">Systems</marc:subfield>
+         <marc:subfield code="h">Theory of communication and control</marc:subfield>
+         <marc:subfield code="j">Perception theory</marc:subfield>
+         <marc:subfield code="t">perception in animals</marc:subfield>
+      </marc:datafield>
+   </marc:record>
+   <marc:record>
+      <marc:leader>*****nw###22*****n##4500</marc:leader>
+      <marc:datafield tag="153" ind1=" " ind2=" ">
+         <marc:subfield code="a">006.4</marc:subfield>
+         <marc:subfield code="h">Generalities</marc:subfield>
+         <marc:subfield code="h">Special computer methods</marc:subfield>
+         <marc:subfield code="j">Computer pattern recognition</marc:subfield>
+      </marc:datafield>
+      <marc:datafield tag="553" ind1="0" ind2="#">
+         <marc:subfield code="w">l</marc:subfield>
+         <marc:subfield code="a">003.52</marc:subfield>
+         <marc:subfield code="h">Generalities</marc:subfield>
+         <marc:subfield code="h">Systems</marc:subfield>
+         <marc:subfield code="h">Theory of communication and control</marc:subfield>
+         <marc:subfield code="j">Perception theory</marc:subfield>
+         <marc:subfield code="t">computer pattern recognition</marc:subfield>
+      </marc:datafield>
+   </marc:record>
+</marc:collection>

--- a/examples/ddc21en-003.54.xml
+++ b/examples/ddc21en-003.54.xml
@@ -1,0 +1,124 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<marc:collection xmlns:marc="http://www.loc.gov/MARC21/slim">
+   <marc:record>
+      <marc:leader>*****nw###22*****n##4500</marc:leader>
+      <marc:datafield tag="084" ind1="0" ind2="#">
+         <marc:subfield code="a">ddc</marc:subfield>
+         <marc:subfield code="c">21</marc:subfield>
+      </marc:datafield>
+      <marc:datafield tag="153" ind1=" " ind2=" ">
+         <marc:subfield code="a">003.54</marc:subfield>
+         <marc:subfield code="h">Generalities</marc:subfield>
+         <marc:subfield code="h">Systems</marc:subfield>
+         <marc:subfield code="h">Theory of communication and control</marc:subfield>
+         <marc:subfield code="j">Information theory</marc:subfield>
+      </marc:datafield>
+      <marc:datafield tag="253" ind1="2" ind2="#">
+         <marc:subfield code="i">Class information theory in communications engineering in</marc:subfield>
+         <marc:subfield code="a">621.3822,</marc:subfield>
+         <marc:subfield code="i">without using notation</marc:subfield>
+         <marc:subfield code="z">1</marc:subfield>
+         <marc:subfield code="a">01154</marc:subfield>
+         <marc:subfield code="i">from Table 1</marc:subfield>
+      </marc:datafield>
+      <marc:datafield tag="253" ind1="2" ind2="#">
+         <marc:subfield code="i">Class information theory in communications engineering of a specific kind of communications with the kind, without using notation</marc:subfield>
+         <marc:subfield code="z">1</marc:subfield>
+         <marc:subfield code="a">01154</marc:subfield>
+         <marc:subfield code="i">from Table 1, e.g., radio</marc:subfield>
+         <marc:subfield code="a">621.384;</marc:subfield>
+         <marc:subfield code="i">class information theory in any other specific subject with the subject, plus notation</marc:subfield>
+         <marc:subfield code="z">1</marc:subfield>
+         <marc:subfield code="a">01154</marc:subfield>
+         <marc:subfield code="i">from Table 1, e.g., information theory in economics</marc:subfield>
+         <marc:subfield code="a">330.01154</marc:subfield>
+      </marc:datafield>
+      <marc:datafield tag="020" ind1="0" ind2="#">
+         <marc:subfield code="w">l</marc:subfield>
+         <marc:subfield code="a">020</marc:subfield>
+         <marc:subfield code="h">Generalities</marc:subfield>
+         <marc:subfield code="j">Library and information sciences</marc:subfield>
+         <marc:subfield code="t">information theory</marc:subfield>
+      </marc:datafield>
+      <marc:datafield tag="553" ind1="0" ind2="#">
+         <marc:subfield code="w">l</marc:subfield>
+         <marc:subfield code="a">302.2</marc:subfield>
+         <marc:subfield code="h">Social sciences</marc:subfield>
+         <marc:subfield code="k">Specific topics in sociology and anthropology</marc:subfield>
+         <marc:subfield code="h">Social interaction</marc:subfield>
+         <marc:subfield code="j">Communication</marc:subfield>
+         <marc:subfield code="t">information theory</marc:subfield>
+      </marc:datafield>
+      <marc:datafield tag="553" ind1="0" ind2="#">
+         <marc:subfield code="w">l</marc:subfield>
+         <marc:subfield code="a">621.3822</marc:subfield>
+         <marc:subfield code="h">Technology (Applied sciences)</marc:subfield>
+         <marc:subfield code="h">Engineering and allied operations</marc:subfield>
+         <marc:subfield code="h">Applied physics</marc:subfield>
+         <marc:subfield code="h">Electrical engineering; lighting; superconductivity; magnetic engineering; applied optics; paraphotic technology; electronics; communications engineering; computers</marc:subfield>
+         <marc:subfield code="h">Electronics, communications engineering</marc:subfield>
+         <marc:subfield code="h">Communications engineering</marc:subfield>
+         <marc:subfield code="j">Signal processing</marc:subfield>
+         <marc:subfield code="t">interdisciplinary works on information theory</marc:subfield>
+      </marc:datafield>
+      <marc:datafield tag="680" ind1="1" ind2="#">
+         <marc:subfield code="i">Theory concerning measurement of quantities of information; accuracy in transmission of messages subject to noise (unwanted, usually random, signals), distortion, and transmission failure; and methods of coding for efficient, accurate transmission</marc:subfield>
+      </marc:datafield>
+      <marc:datafield tag="680" ind1="1" ind2="#">
+         <marc:subfield code="i">Class here coding theory</marc:subfield>
+      </marc:datafield>
+      <marc:datafield tag="685" ind1="0" ind2="0">
+         <marc:subfield code="t">Information theory</marc:subfield>
+         <marc:subfield code="i">formerly located in</marc:subfield>
+         <marc:subfield code="b">001.539</marc:subfield>
+         <marc:subfield code="d">19890306</marc:subfield>
+         <marc:subfield code="2">20</marc:subfield>
+      </marc:datafield>
+      <marc:datafield tag="685" ind1="0" ind2="0">
+         <marc:subfield code="t">Coding theory</marc:subfield>
+         <marc:subfield code="i">formerly located in</marc:subfield>
+         <marc:subfield code="b">519.4</marc:subfield>
+         <marc:subfield code="d">19890306</marc:subfield>
+         <marc:subfield code="2">20</marc:subfield>
+      </marc:datafield>
+      <marc:datafield tag="753" ind1=" " ind2=" ">
+         <marc:subfield code="a">Coding theory</marc:subfield>
+      </marc:datafield>
+      <marc:datafield tag="753" ind1=" " ind2=" ">
+         <marc:subfield code="a">Information theory</marc:subfield>
+      </marc:datafield>
+      <marc:datafield tag="753" ind1=" " ind2=" ">
+         <marc:subfield code="a">Signal theory</marc:subfield>
+      </marc:datafield>
+      <marc:datafield tag="753" ind1=" " ind2=" ">
+         <marc:subfield code="a">Signal theory</marc:subfield>
+         <marc:subfield code="b">systems</marc:subfield>
+      </marc:datafield>
+      <marc:datafield tag="011" ind1="1" ind2="#">
+         <marc:subfield code="z">1</marc:subfield>
+         <marc:subfield code="b">011</marc:subfield>
+         <marc:subfield code="z">1</marc:subfield>
+         <marc:subfield code="a">011</marc:subfield>
+         <marc:subfield code="r">003</marc:subfield>
+         <marc:subfield code="s">54</marc:subfield>
+         <marc:subfield code="z">1</marc:subfield>
+         <marc:subfield code="u">01154</marc:subfield>
+      </marc:datafield>
+      <marc:datafield tag="765" ind1="1" ind2="#">
+         <marc:subfield code="b">330</marc:subfield>
+         <marc:subfield code="z">1</marc:subfield>
+         <marc:subfield code="a">0</marc:subfield>
+         <marc:subfield code="z">1</marc:subfield>
+         <marc:subfield code="s">011</marc:subfield>
+         <marc:subfield code="u">330.01154</marc:subfield>
+      </marc:datafield>
+      <marc:datafield tag="765" ind1="1" ind2="#">
+         <marc:subfield code="b">330.011</marc:subfield>
+         <marc:subfield code="z">1</marc:subfield>
+         <marc:subfield code="a">011</marc:subfield>
+         <marc:subfield code="r">003</marc:subfield>
+         <marc:subfield code="s">54</marc:subfield>
+         <marc:subfield code="u">330.01154</marc:subfield>
+      </marc:datafield>
+   </marc:record>
+</marc:collection>

--- a/examples/ddc21en-003.56.xml
+++ b/examples/ddc21en-003.56.xml
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<marc:collection xmlns:marc="http://www.loc.gov/MARC21/slim">
+   <marc:record>
+      <marc:leader>*****nw###22*****n##4500</marc:leader>
+      <marc:datafield tag="084" ind1="0" ind2="#">
+         <marc:subfield code="a">ddc</marc:subfield>
+         <marc:subfield code="c">21</marc:subfield>
+      </marc:datafield>
+      <marc:datafield tag="153" ind1=" " ind2=" ">
+         <marc:subfield code="a">003.56</marc:subfield>
+         <marc:subfield code="h">Generalities</marc:subfield>
+         <marc:subfield code="h">Systems</marc:subfield>
+         <marc:subfield code="h">Theory of communication and control</marc:subfield>
+         <marc:subfield code="j">Decision theory</marc:subfield>
+      </marc:datafield>
+      <marc:datafield tag="685" ind1="0" ind2="3">
+         <marc:subfield code="t">Decision theory</marc:subfield>
+         <marc:subfield code="b">003</marc:subfield>
+         <marc:subfield code="d">19890306</marc:subfield>
+         <marc:subfield code="2">20</marc:subfield>
+      </marc:datafield>
+      <marc:datafield tag="753" ind1=" " ind2=" ">
+         <marc:subfield code="a">Decision theory</marc:subfield>
+      </marc:datafield>
+   </marc:record>
+   <marc:record>
+      <marc:leader>*****nw###22*****n##4500</marc:leader>
+      <marc:datafield tag="153" ind1=" " ind2=" ">
+         <marc:subfield code="a">153.83</marc:subfield>
+         <marc:subfield code="h">Philosophy, paranormal phenomena, psychology</marc:subfield>
+         <marc:subfield code="h">Psychology</marc:subfield>
+         <marc:subfield code="k">Specific topics in psychology</marc:subfield>
+         <marc:subfield code="h">Conscious mental processes and intelligence</marc:subfield>
+         <marc:subfield code="h">Will (Volition)</marc:subfield>
+         <marc:subfield code="j">Choice and decision</marc:subfield>
+      </marc:datafield>
+   </marc:record>
+   <marc:record>
+      <marc:leader>*****nw###22*****n##4500</marc:leader>
+      <marc:datafield tag="153" ind1=" " ind2=" ">
+         <marc:subfield code="a">511.65</marc:subfield>
+         <marc:subfield code="h">Natural sciences and mathematics</marc:subfield>
+         <marc:subfield code="h">Mathematics</marc:subfield>
+         <marc:subfield code="h">General principles of mathematics</marc:subfield>
+         <marc:subfield code="h">Combinatorial analysis</marc:subfield>
+         <marc:subfield code="j">Choice</marc:subfield>
+      </marc:datafield>
+      <marc:datafield tag="553" ind1="0" ind2="#">
+         <marc:subfield code="w">l</marc:subfield>
+         <marc:subfield code="a">003.56</marc:subfield>
+         <marc:subfield code="h">Generalities</marc:subfield>
+         <marc:subfield code="h">Systems</marc:subfield>
+         <marc:subfield code="h">Theory of communication and control</marc:subfield>
+         <marc:subfield code="j">Decision theory</marc:subfield>
+         <marc:subfield code="t">decision theory in combinatorial analysis</marc:subfield>
+      </marc:datafield>
+   </marc:record>
+   <marc:record>
+      <marc:leader>*****nw###22*****n##4500</marc:leader>
+      <marc:datafield tag="153" ind1=" " ind2=" ">
+         <marc:subfield code="a">658.40301</marc:subfield>
+         <marc:subfield code="h">Technology (Applied sciences)</marc:subfield>
+         <marc:subfield code="h">Management and auxiliary services</marc:subfield>
+         <marc:subfield code="h">General management</marc:subfield>
+         <marc:subfield code="h">Executive management</marc:subfield>
+         <marc:subfield code="k">Specific executive management activities</marc:subfield>
+         <marc:subfield code="h">Decision making and information management</marc:subfield>
+         <marc:subfield code="j">Philosophy and theory of decision making</marc:subfield>
+      </marc:datafield>
+      <marc:datafield tag="553" ind1="0" ind2="#">
+         <marc:subfield code="w">l</marc:subfield>
+         <marc:subfield code="a">003.56</marc:subfield>
+         <marc:subfield code="h">Generalities</marc:subfield>
+         <marc:subfield code="h">Systems</marc:subfield>
+         <marc:subfield code="h">Theory of communication and control</marc:subfield>
+         <marc:subfield code="j">Decision theory</marc:subfield>
+         <marc:subfield code="t">decision theory in management</marc:subfield>
+      </marc:datafield>
+   </marc:record>
+</marc:collection>

--- a/examples/ddc21en-003.7.xml
+++ b/examples/ddc21en-003.7.xml
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<marc:collection xmlns:marc="http://www.loc.gov/MARC21/slim">
+   <marc:record>
+      <marc:leader>*****nw###22*****n##4500</marc:leader>
+      <marc:datafield tag="084" ind1="0" ind2="#">
+         <marc:subfield code="a">ddc</marc:subfield>
+         <marc:subfield code="c">21</marc:subfield>
+      </marc:datafield>
+      <marc:datafield tag="153" ind1=" " ind2=" ">
+         <marc:subfield code="a">003.7</marc:subfield>
+         <marc:subfield code="h">Generalities</marc:subfield>
+         <marc:subfield code="h">Systems</marc:subfield>
+         <marc:subfield code="j">Kinds of systems</marc:subfield>
+      </marc:datafield>
+      <marc:datafield tag="680" ind1="0" ind2="#">
+         <marc:subfield code="i">Including deterministic, hierarchical, lumped-parameter, self-organizing, small-scale systems</marc:subfield>
+      </marc:datafield>
+      <marc:datafield tag="684" ind1="0" ind2="#">
+         <marc:subfield code="a">003.7</marc:subfield>
+         <marc:subfield code="j">Kinds of systems</marc:subfield>
+      </marc:datafield>
+      <marc:datafield tag="684" ind1="1" ind2="#">
+         <marc:subfield code="i">Many kinds of systems are defined in terms of the equations used to model them, e.g., distributed-parameter systems are defined as systems governed by partial differential equations. Other equations may be used to model the behavior of the same real-world system. Class a work about a specific kind of system according to the way the work describes the system, e.g., a work that discusses applying the mathematics of stochastic (random) processes to systems</marc:subfield>
+         <marc:subfield code="a">003.76.</marc:subfield>
+      </marc:datafield>
+      <marc:datafield tag="685" ind1="0" ind2="3">
+         <marc:subfield code="t">Kinds of systems</marc:subfield>
+         <marc:subfield code="b">003</marc:subfield>
+         <marc:subfield code="d">19890306</marc:subfield>
+         <marc:subfield code="2">20</marc:subfield>
+      </marc:datafield>
+      <marc:datafield tag="685" ind1="0" ind2="0">
+         <marc:subfield code="t">Self-organizing systems</marc:subfield>
+         <marc:subfield code="i">formerly located in</marc:subfield>
+         <marc:subfield code="b">001.533</marc:subfield>
+         <marc:subfield code="d">19890306</marc:subfield>
+         <marc:subfield code="2">20</marc:subfield>
+      </marc:datafield>
+      <marc:datafield tag="753" ind1=" " ind2=" ">
+         <marc:subfield code="a">Systems</marc:subfield>
+      </marc:datafield>
+      <marc:datafield tag="753" ind1=" " ind2=" ">
+         <marc:subfield code="a">Deterministic systems</marc:subfield>
+      </marc:datafield>
+      <marc:datafield tag="753" ind1=" " ind2=" ">
+         <marc:subfield code="a">Hierarchical systems</marc:subfield>
+      </marc:datafield>
+      <marc:datafield tag="753" ind1=" " ind2=" ">
+         <marc:subfield code="a">Lumped-parameter systems</marc:subfield>
+      </marc:datafield>
+      <marc:datafield tag="753" ind1=" " ind2=" ">
+         <marc:subfield code="a">Self-organizing systems</marc:subfield>
+      </marc:datafield>
+      <marc:datafield tag="753" ind1=" " ind2=" ">
+         <marc:subfield code="a">Small-scale systems</marc:subfield>
+      </marc:datafield>
+   </marc:record>
+   <marc:record>
+      <marc:leader>*****nw###22*****n##4500</marc:leader>
+      <marc:datafield tag="153" ind1=" " ind2=" ">
+         <marc:subfield code="a">003.8</marc:subfield>
+         <marc:subfield code="h">Generalities</marc:subfield>
+         <marc:subfield code="h">Systems</marc:subfield>
+         <marc:subfield code="j">Systems distinguished in relation to time</marc:subfield>
+      </marc:datafield>
+      <marc:datafield tag="553" ind1="0" ind2="#">
+         <marc:subfield code="w">jg</marc:subfield>
+         <marc:subfield code="a">003.7</marc:subfield>
+         <marc:subfield code="h">Generalities</marc:subfield>
+         <marc:subfield code="h">Systems</marc:subfield>
+         <marc:subfield code="j">Kinds of systems</marc:subfield>
+         <marc:subfield code="t">systems distinguished in relation to time</marc:subfield>
+      </marc:datafield>
+   </marc:record>
+</marc:collection>

--- a/examples/ddc21en-003.71.xml
+++ b/examples/ddc21en-003.71.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<marc:collection xmlns:marc="http://www.loc.gov/MARC21/slim">
+   <marc:record>
+      <marc:leader>*****nw###22*****n##4500</marc:leader>
+      <marc:datafield tag="084" ind1="0" ind2="#">
+         <marc:subfield code="a">ddc</marc:subfield>
+         <marc:subfield code="c">21</marc:subfield>
+      </marc:datafield>
+      <marc:datafield tag="153" ind1=" " ind2=" ">
+         <marc:subfield code="a">003.71</marc:subfield>
+         <marc:subfield code="h">Generalities</marc:subfield>
+         <marc:subfield code="h">Systems</marc:subfield>
+         <marc:subfield code="h">Kinds of systems</marc:subfield>
+         <marc:subfield code="j">Large-scale systems</marc:subfield>
+      </marc:datafield>
+      <marc:datafield tag="680" ind1="1" ind2="#">
+         <marc:subfield code="i">Limited to works emphasizing that the systems are large</marc:subfield>
+      </marc:datafield>
+      <marc:datafield tag="685" ind1="0" ind2="3">
+         <marc:subfield code="t">Large-scale systems</marc:subfield>
+         <marc:subfield code="b">003</marc:subfield>
+         <marc:subfield code="d">19890306</marc:subfield>
+         <marc:subfield code="2">20</marc:subfield>
+      </marc:datafield>
+      <marc:datafield tag="753" ind1=" " ind2=" ">
+         <marc:subfield code="a">Large-scale systems</marc:subfield>
+      </marc:datafield>
+   </marc:record>
+</marc:collection>

--- a/examples/ddc21en-6--98.xml
+++ b/examples/ddc21en-6--98.xml
@@ -1,0 +1,182 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<marc:collection xmlns:marc="http://www.loc.gov/MARC21/slim">
+   <marc:record>
+      <marc:leader>*****nw###22*****n##4500</marc:leader>
+      <marc:datafield tag="084" ind1="0" ind2="#">
+         <marc:subfield code="a">ddc</marc:subfield>
+         <marc:subfield code="c">21</marc:subfield>
+      </marc:datafield>
+      <marc:datafield tag="153" ind1="1" ind2="#">
+         <marc:subfield code="z">6</marc:subfield>
+         <marc:subfield code="a">98</marc:subfield>
+         <marc:subfield code="h">Languages</marc:subfield>
+         <marc:subfield code="h">Other languages</marc:subfield>
+         <marc:subfield code="j">South American native languages</marc:subfield>
+      </marc:datafield>
+      <marc:datafield tag="553" ind1="1" ind2="#">
+         <marc:subfield code="w">j</marc:subfield>
+         <marc:subfield code="z">6</marc:subfield>
+         <marc:subfield code="a">9741</marc:subfield>
+         <marc:subfield code="h">Languages</marc:subfield>
+         <marc:subfield code="h">Other languages</marc:subfield>
+         <marc:subfield code="h">North American native languages</marc:subfield>
+         <marc:subfield code="h">Penutian, Mixe-Zoquean, Mayan, Uto-Aztecan, Kiowa-Tanoan languages</marc:subfield>
+         <marc:subfield code="j">Penutian, Mixe-Zoquean, Mayan languages</marc:subfield>
+         <marc:subfield code="t">Araucanian, Uru-Chipaya languages</marc:subfield>
+      </marc:datafield>
+      <marc:datafield tag="553" ind1="1" ind2="#">
+         <marc:subfield code="w">j</marc:subfield>
+         <marc:subfield code="z">6</marc:subfield>
+         <marc:subfield code="a">982</marc:subfield>
+         <marc:subfield code="h">Languages</marc:subfield>
+         <marc:subfield code="h">Other languages</marc:subfield>
+         <marc:subfield code="h">South American native languages</marc:subfield>
+         <marc:subfield code="j">Chibchan and Paezan languages</marc:subfield>
+         <marc:subfield code="t">Yanomam languages, Warao</marc:subfield>
+      </marc:datafield>
+      <marc:datafield tag="553" ind1="1" ind2="#">
+         <marc:subfield code="w">anaa</marc:subfield>
+         <marc:subfield code="z">6</marc:subfield>
+         <marc:subfield code="a">983</marc:subfield>
+         <marc:subfield code="h">Languages</marc:subfield>
+         <marc:subfield code="h">Other languages</marc:subfield>
+         <marc:subfield code="h">South American native languages</marc:subfield>
+         <marc:subfield code="j">Quechuan (Kechuan), Aymaran, Tucanoan, Tupí, Arawakan languages</marc:subfield>
+         <marc:subfield code="t">Yaruro</marc:subfield>
+      </marc:datafield>
+      <marc:datafield tag="553" ind1="1" ind2="#">
+         <marc:subfield code="w">j</marc:subfield>
+         <marc:subfield code="z">6</marc:subfield>
+         <marc:subfield code="a">9837</marc:subfield>
+         <marc:subfield code="h">Languages</marc:subfield>
+         <marc:subfield code="h">Other languages</marc:subfield>
+         <marc:subfield code="h">South American native languages</marc:subfield>
+         <marc:subfield code="h">Quechuan (Kechuan), Aymaran, Tucanoan, Tupí, Arawakan languages</marc:subfield>
+         <marc:subfield code="j">Jivaroan languages</marc:subfield>
+         <marc:subfield code="t">Yaruro</marc:subfield>
+      </marc:datafield>
+      <marc:datafield tag="553" ind1="1" ind2="#">
+         <marc:subfield code="w">j</marc:subfield>
+         <marc:subfield code="z">6</marc:subfield>
+         <marc:subfield code="a">984</marc:subfield>
+         <marc:subfield code="h">Languages</marc:subfield>
+         <marc:subfield code="h">Other languages</marc:subfield>
+         <marc:subfield code="h">South American native languages</marc:subfield>
+         <marc:subfield code="j">Carib, Macro-Ge, Nambiquaran, Panoan languages</marc:subfield>
+         <marc:subfield code="t">Hixkaryana, Mataco-Guaicuru, Tacanan, Witotoan languages</marc:subfield>
+      </marc:datafield>
+      <marc:datafield tag="680" ind1="0" ind2="#">
+         <marc:subfield code="i">Including Araucanian, Cahuapanan, Mataco-Guaicuru, Tacanan, Uru-Chipaya, Witotoan, Yanomam languages; Hixkaryana, Warao, Yaruro</marc:subfield>
+      </marc:datafield>
+      <marc:datafield tag="753" ind1=" " ind2=" ">
+         <marc:subfield code="a">American Indian languages</marc:subfield>
+         <marc:subfield code="c">South America</marc:subfield>
+      </marc:datafield>
+      <marc:datafield tag="753" ind1=" " ind2=" ">
+         <marc:subfield code="a">American native languages</marc:subfield>
+         <marc:subfield code="c">South America</marc:subfield>
+      </marc:datafield>
+      <marc:datafield tag="753" ind1=" " ind2=" ">
+         <marc:subfield code="a">Amerind languages</marc:subfield>
+         <marc:subfield code="c">South America</marc:subfield>
+      </marc:datafield>
+      <marc:datafield tag="753" ind1=" " ind2=" ">
+         <marc:subfield code="a">Andoke language</marc:subfield>
+      </marc:datafield>
+      <marc:datafield tag="753" ind1=" " ind2=" ">
+         <marc:subfield code="a">Andoque language</marc:subfield>
+      </marc:datafield>
+      <marc:datafield tag="753" ind1=" " ind2=" ">
+         <marc:subfield code="a">Araona language</marc:subfield>
+      </marc:datafield>
+      <marc:datafield tag="753" ind1=" " ind2=" ">
+         <marc:subfield code="a">Araucanian language</marc:subfield>
+      </marc:datafield>
+      <marc:datafield tag="753" ind1=" " ind2=" ">
+         <marc:subfield code="a">Cahuapanan languages</marc:subfield>
+      </marc:datafield>
+      <marc:datafield tag="753" ind1=" " ind2=" ">
+         <marc:subfield code="a">Catuquina language (Catuquinan)</marc:subfield>
+      </marc:datafield>
+      <marc:datafield tag="753" ind1=" " ind2=" ">
+         <marc:subfield code="a">Chapacura language</marc:subfield>
+      </marc:datafield>
+      <marc:datafield tag="753" ind1=" " ind2=" ">
+         <marc:subfield code="a">Chayahuita language</marc:subfield>
+      </marc:datafield>
+      <marc:datafield tag="753" ind1=" " ind2=" ">
+         <marc:subfield code="a">Chipaya language</marc:subfield>
+      </marc:datafield>
+      <marc:datafield tag="753" ind1=" " ind2=" ">
+         <marc:subfield code="a">Chulupí language</marc:subfield>
+      </marc:datafield>
+      <marc:datafield tag="753" ind1=" " ind2=" ">
+         <marc:subfield code="a">Guaicuru languages</marc:subfield>
+      </marc:datafield>
+      <marc:datafield tag="753" ind1=" " ind2=" ">
+         <marc:subfield code="a">Guaycuruan languages</marc:subfield>
+      </marc:datafield>
+      <marc:datafield tag="753" ind1=" " ind2=" ">
+         <marc:subfield code="a">Hishkaryana language</marc:subfield>
+      </marc:datafield>
+      <marc:datafield tag="753" ind1=" " ind2=" ">
+         <marc:subfield code="a">Hixkaryana language</marc:subfield>
+      </marc:datafield>
+      <marc:datafield tag="753" ind1=" " ind2=" ">
+         <marc:subfield code="a">Indian languages (American)</marc:subfield>
+         <marc:subfield code="c">South America</marc:subfield>
+      </marc:datafield>
+      <marc:datafield tag="753" ind1=" " ind2=" ">
+         <marc:subfield code="a">Mapuche language</marc:subfield>
+      </marc:datafield>
+      <marc:datafield tag="753" ind1=" " ind2=" ">
+         <marc:subfield code="a">Mapudungu language</marc:subfield>
+      </marc:datafield>
+      <marc:datafield tag="753" ind1=" " ind2=" ">
+         <marc:subfield code="a">Mataco languages</marc:subfield>
+      </marc:datafield>
+      <marc:datafield tag="753" ind1=" " ind2=" ">
+         <marc:subfield code="a">Mataco-Guaicuru languages</marc:subfield>
+      </marc:datafield>
+      <marc:datafield tag="753" ind1=" " ind2=" ">
+         <marc:subfield code="a">Murui language</marc:subfield>
+      </marc:datafield>
+      <marc:datafield tag="753" ind1=" " ind2=" ">
+         <marc:subfield code="a">Native American languages</marc:subfield>
+         <marc:subfield code="c">South America</marc:subfield>
+      </marc:datafield>
+      <marc:datafield tag="753" ind1=" " ind2=" ">
+         <marc:subfield code="a">South American native languages</marc:subfield>
+      </marc:datafield>
+      <marc:datafield tag="753" ind1=" " ind2=" ">
+         <marc:subfield code="a">Tacanan languages</marc:subfield>
+      </marc:datafield>
+      <marc:datafield tag="753" ind1=" " ind2=" ">
+         <marc:subfield code="a">Tucuna language</marc:subfield>
+      </marc:datafield>
+      <marc:datafield tag="753" ind1=" " ind2=" ">
+         <marc:subfield code="a">Uru-Chipaya languages</marc:subfield>
+      </marc:datafield>
+      <marc:datafield tag="753" ind1=" " ind2=" ">
+         <marc:subfield code="a">Waica language</marc:subfield>
+      </marc:datafield>
+      <marc:datafield tag="753" ind1=" " ind2=" ">
+         <marc:subfield code="a">Warao language</marc:subfield>
+      </marc:datafield>
+      <marc:datafield tag="753" ind1=" " ind2=" ">
+         <marc:subfield code="a">Warrau language</marc:subfield>
+      </marc:datafield>
+      <marc:datafield tag="753" ind1=" " ind2=" ">
+         <marc:subfield code="a">Witotoan languages</marc:subfield>
+      </marc:datafield>
+      <marc:datafield tag="753" ind1=" " ind2=" ">
+         <marc:subfield code="a">Yanomam languages</marc:subfield>
+      </marc:datafield>
+      <marc:datafield tag="753" ind1=" " ind2=" ">
+         <marc:subfield code="a">Yanomamo language</marc:subfield>
+      </marc:datafield>
+      <marc:datafield tag="753" ind1=" " ind2=" ">
+         <marc:subfield code="a">Yaruro language</marc:subfield>
+      </marc:datafield>
+   </marc:record>
+</marc:collection>

--- a/examples/ddc21en-6--982.xml
+++ b/examples/ddc21en-6--982.xml
@@ -1,0 +1,99 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<marc:collection xmlns:marc="http://www.loc.gov/MARC21/slim">
+   <marc:record>
+      <marc:leader>*****nw###22*****n##4500</marc:leader>
+      <marc:datafield tag="084" ind1="0" ind2="#">
+         <marc:subfield code="a">ddc</marc:subfield>
+         <marc:subfield code="c">21</marc:subfield>
+      </marc:datafield>
+      <marc:datafield tag="153" ind1=" " ind2=" ">
+         <marc:subfield code="z">6</marc:subfield>
+         <marc:subfield code="a">982</marc:subfield>
+         <marc:subfield code="h">Languages</marc:subfield>
+         <marc:subfield code="h">Other languages</marc:subfield>
+         <marc:subfield code="h">South American native languages</marc:subfield>
+         <marc:subfield code="j">Chibchan and Paezan languages</marc:subfield>
+      </marc:datafield>
+      <marc:datafield tag="553" ind1="1" ind2="#">
+         <marc:subfield code="w">j</marc:subfield>
+         <marc:subfield code="z">6</marc:subfield>
+         <marc:subfield code="a">978</marc:subfield>
+         <marc:subfield code="h">Languages</marc:subfield>
+         <marc:subfield code="h">Other languages</marc:subfield>
+         <marc:subfield code="h">North American native languages</marc:subfield>
+         <marc:subfield code="j">Chibchan languages of North America, Misumalpan languages</marc:subfield>
+         <marc:subfield code="t">comprehensive works on Chibchan language</marc:subfield>
+      </marc:datafield>
+      <marc:datafield tag="753" ind1=" " ind2=" ">
+         <marc:subfield code="a">Cayapa language</marc:subfield>
+      </marc:datafield>
+      <marc:datafield tag="753" ind1=" " ind2=" ">
+         <marc:subfield code="a">Chachi language</marc:subfield>
+      </marc:datafield>
+      <marc:datafield tag="753" ind1=" " ind2=" ">
+         <marc:subfield code="a">Chibchan languages</marc:subfield>
+      </marc:datafield>
+      <marc:datafield tag="753" ind1=" " ind2=" ">
+         <marc:subfield code="a">Coconuco language</marc:subfield>
+      </marc:datafield>
+      <marc:datafield tag="753" ind1=" " ind2=" ">
+         <marc:subfield code="a">Cuna language</marc:subfield>
+      </marc:datafield>
+      <marc:datafield tag="753" ind1=" " ind2=" ">
+         <marc:subfield code="a">Guambiano language</marc:subfield>
+      </marc:datafield>
+      <marc:datafield tag="753" ind1=" " ind2=" ">
+         <marc:subfield code="a">Kuna language</marc:subfield>
+      </marc:datafield>
+      <marc:datafield tag="753" ind1=" " ind2=" ">
+         <marc:subfield code="a">Moguex language</marc:subfield>
+      </marc:datafield>
+      <marc:datafield tag="753" ind1=" " ind2=" ">
+         <marc:subfield code="a">Paez language</marc:subfield>
+      </marc:datafield>
+      <marc:datafield tag="753" ind1=" " ind2=" ">
+         <marc:subfield code="a">Paezan languages</marc:subfield>
+      </marc:datafield>
+   </marc:record>
+   <marc:record>
+      <marc:leader>*****nw###22*****n##4500</marc:leader>
+      <marc:datafield tag="153" ind1=" " ind2=" ">
+         <marc:subfield code="z">6</marc:subfield>
+         <marc:subfield code="a">978</marc:subfield>
+         <marc:subfield code="h">Languages</marc:subfield>
+         <marc:subfield code="h">Other languages</marc:subfield>
+         <marc:subfield code="h">North American native languages</marc:subfield>
+         <marc:subfield code="j">Chibchan languages of North American, Misumalpan languages</marc:subfield>
+      </marc:datafield>
+      <marc:datafield tag="553" ind1=" " ind2=" ">
+         <marc:subfield code="w">jh</marc:subfield>
+         <marc:subfield code="z">6</marc:subfield>
+         <marc:subfield code="a">982</marc:subfield>
+         <marc:subfield code="h">Languages</marc:subfield>
+         <marc:subfield code="h">Other languages</marc:subfield>
+         <marc:subfield code="h">South American native languages</marc:subfield>
+         <marc:subfield code="j">Chibchan and Paezan languages</marc:subfield>
+         <marc:subfield code="t">Chibchan languages of North American</marc:subfield>
+      </marc:datafield>
+   </marc:record>
+   <marc:record>
+      <marc:leader>*****nw###22*****n##4500</marc:leader>
+      <marc:datafield tag="153" ind1=" " ind2=" ">
+         <marc:subfield code="z">6</marc:subfield>
+         <marc:subfield code="a">98</marc:subfield>
+         <marc:subfield code="h">Languages</marc:subfield>
+         <marc:subfield code="h">Other languages</marc:subfield>
+         <marc:subfield code="j">South American native languages</marc:subfield>
+      </marc:datafield>
+      <marc:datafield tag="553" ind1="1" ind2="#">
+         <marc:subfield code="w">j</marc:subfield>
+         <marc:subfield code="z">6</marc:subfield>
+         <marc:subfield code="a">982</marc:subfield>
+         <marc:subfield code="h">Languages</marc:subfield>
+         <marc:subfield code="h">Other languages</marc:subfield>
+         <marc:subfield code="h">South American native languages</marc:subfield>
+         <marc:subfield code="j">Chibchan and Paezan languages</marc:subfield>
+         <marc:subfield code="t">Yanomam languages, Warao</marc:subfield>
+      </marc:datafield>
+   </marc:record>
+</marc:collection>

--- a/examples/ddc21en-6--983.xml
+++ b/examples/ddc21en-6--983.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<marc:collection xmlns:marc="http://www.loc.gov/MARC21/slim">
+   <marc:record>
+      <marc:leader>*****nw###22*****n##4500</marc:leader>
+      <marc:datafield tag="084" ind1="0" ind2="#">
+         <marc:subfield code="a">ddc</marc:subfield>
+         <marc:subfield code="c">21</marc:subfield>
+      </marc:datafield>
+      <marc:datafield tag="153" ind1=" " ind2=" ">
+         <marc:subfield code="z">6</marc:subfield>
+         <marc:subfield code="a">983</marc:subfield>
+         <marc:subfield code="h">Languages</marc:subfield>
+         <marc:subfield code="h">Other languages</marc:subfield>
+         <marc:subfield code="h">South American native languages</marc:subfield>
+         <marc:subfield code="j">Quechuan (Kechuan), Aymaran, Tucanoan, Tupí, Arawakan languages</marc:subfield>
+      </marc:datafield>
+      <marc:datafield tag="680" ind1="1" ind2="#">
+         <marc:subfield code="i">Former heading: Andean-Equatorial languages</marc:subfield>
+      </marc:datafield>
+      <marc:datafield tag="685" ind1="2" ind2="2">
+         <marc:subfield code="i">Use of this number for</marc:subfield>
+         <marc:subfield code="t">Yaruro</marc:subfield>
+         <marc:subfield code="i">discontinued; class in</marc:subfield>
+         <marc:subfield code="z">6</marc:subfield>
+         <marc:subfield code="a">98</marc:subfield>
+         <marc:subfield code="d">19960930</marc:subfield>
+         <marc:subfield code="2">21</marc:subfield>
+      </marc:datafield>
+      <marc:datafield tag="153" ind1=" " ind2=" ">
+         <marc:subfield code="z">6</marc:subfield>
+         <marc:subfield code="a">98</marc:subfield>
+         <marc:subfield code="h">Languages</marc:subfield>
+         <marc:subfield code="h">Other Languages</marc:subfield>
+         <marc:subfield code="j">South American native languages</marc:subfield>
+      </marc:datafield>
+      <marc:datafield tag="553" ind1="1" ind2="#">
+         <marc:subfield code="w">anaa</marc:subfield>
+         <marc:subfield code="z">6</marc:subfield>
+         <marc:subfield code="a">983</marc:subfield>
+         <marc:subfield code="h">Languages</marc:subfield>
+         <marc:subfield code="h">Other languages</marc:subfield>
+         <marc:subfield code="h">South American native languages</marc:subfield>
+         <marc:subfield code="j">Quechuan (Kechuan), Aymaran, Tucanoan, Tupí, Arawakan languages</marc:subfield>
+         <marc:subfield code="t">Yaruro</marc:subfield>
+      </marc:datafield>
+   </marc:record>
+</marc:collection>

--- a/examples/ddc21en-6--9832.xml
+++ b/examples/ddc21en-6--9832.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<marc:collection xmlns:marc="http://www.loc.gov/MARC21/slim">
+   <marc:record>
+      <marc:leader>*****nw###22*****n##4500</marc:leader>
+      <marc:datafield tag="084" ind1="0" ind2="#">
+         <marc:subfield code="a">ddc</marc:subfield>
+         <marc:subfield code="c">21</marc:subfield>
+      </marc:datafield>
+      <marc:datafield tag="153" ind1=" " ind2=" ">
+         <marc:subfield code="z">6</marc:subfield>
+         <marc:subfield code="a">9832</marc:subfield>
+         <marc:subfield code="h">Languages</marc:subfield>
+         <marc:subfield code="h">Other languages</marc:subfield>
+         <marc:subfield code="h">South American native languages</marc:subfield>
+         <marc:subfield code="h">Quechuan (Kechuan), Aymaran, Tucanoan, Tupí, Arawakan languages</marc:subfield>
+         <marc:subfield code="j">Quechuan (Kechuan) and Aymaran languages</marc:subfield>
+      </marc:datafield>
+      <marc:datafield tag="680" ind1="1" ind2="#">
+         <marc:subfield code="i">Former heading: Andean languages</marc:subfield>
+      </marc:datafield>
+      <marc:datafield tag="753" ind1=" " ind2=" ">
+         <marc:subfield code="a">Andean languages</marc:subfield>
+      </marc:datafield>
+   </marc:record>
+</marc:collection>

--- a/examples/ddc21en-6--98323.xml
+++ b/examples/ddc21en-6--98323.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<marc:collection xmlns:marc="http://www.loc.gov/MARC21/slim">
+   <marc:record>
+      <marc:leader>*****nw###22*****n##4500</marc:leader>
+      <marc:datafield tag="084" ind1="0" ind2="#">
+         <marc:subfield code="a">ddc</marc:subfield>
+         <marc:subfield code="c">21</marc:subfield>
+      </marc:datafield>
+      <marc:datafield tag="153" ind1=" " ind2=" ">
+         <marc:subfield code="z">6</marc:subfield>
+         <marc:subfield code="a">98323</marc:subfield>
+         <marc:subfield code="h">Languages</marc:subfield>
+         <marc:subfield code="h">Other languages</marc:subfield>
+         <marc:subfield code="h">South American native languages</marc:subfield>
+         <marc:subfield code="h">Quechuan (Kechuan), Aymaran, Tucanoan, Tupí, Arawakan languages</marc:subfield>
+         <marc:subfield code="h">Quechuan (Kechuan) and Aymaran languages</marc:subfield>
+         <marc:subfield code="j">Quechuan (Kechuan) languages. Quechua (Kechua)</marc:subfield>
+      </marc:datafield>
+      <marc:datafield tag="685" ind1="2" ind2="0">
+         <marc:subfield code="t">Aymaran languages</marc:subfield>
+         <marc:subfield code="i">relocated to</marc:subfield>
+         <marc:subfield code="z">6</marc:subfield>
+         <marc:subfield code="a">98324</marc:subfield>
+         <marc:subfield code="d">19960930</marc:subfield>
+         <marc:subfield code="2">21</marc:subfield>
+      </marc:datafield>
+      <marc:datafield tag="753" ind1=" " ind2=" ">
+         <marc:subfield code="a">Kechua language</marc:subfield>
+      </marc:datafield>
+      <marc:datafield tag="753" ind1=" " ind2=" ">
+         <marc:subfield code="a">Kechuan languages</marc:subfield>
+      </marc:datafield>
+      <marc:datafield tag="753" ind1=" " ind2=" ">
+         <marc:subfield code="a">Quechua language</marc:subfield>
+      </marc:datafield>
+      <marc:datafield tag="753" ind1=" " ind2=" ">
+         <marc:subfield code="a">Quechuan languages</marc:subfield>
+      </marc:datafield>
+   </marc:record>
+</marc:collection>

--- a/examples/ddc21en-6--98324.xml
+++ b/examples/ddc21en-6--98324.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<marc:collection xmlns:marc="http://www.loc.gov/MARC21/slim">
+   <marc:record>
+      <marc:leader>*****nw###22*****n##4500</marc:leader>
+      <marc:datafield tag="084" ind1="0" ind2="#">
+         <marc:subfield code="a">ddc</marc:subfield>
+         <marc:subfield code="c">21</marc:subfield>
+      </marc:datafield>
+      <marc:datafield tag="153" ind1=" " ind2=" ">
+         <marc:subfield code="z">6</marc:subfield>
+         <marc:subfield code="a">98324</marc:subfield>
+         <marc:subfield code="h">Languages</marc:subfield>
+         <marc:subfield code="h">Other languages</marc:subfield>
+         <marc:subfield code="h">South American native languages</marc:subfield>
+         <marc:subfield code="h">Quechuan (Kechuan), Aymaran, Tucanoan, Tupí, Arawakan languages</marc:subfield>
+         <marc:subfield code="h">Quechuan (Kechuan) and Aymaran languages</marc:subfield>
+         <marc:subfield code="j">Aymaran languages. Aymara</marc:subfield>
+      </marc:datafield>
+      <marc:datafield tag="553" ind1="1" ind2="#">
+         <marc:subfield code="z">6</marc:subfield>
+         <marc:subfield code="a">98323</marc:subfield>
+         <marc:subfield code="h">Languages</marc:subfield>
+         <marc:subfield code="h">Other languages</marc:subfield>
+         <marc:subfield code="h">South American native languages</marc:subfield>
+         <marc:subfield code="h">Quechuan (Kechuan), Aymaran, Tucanoan, Tupí, Arawakan languages</marc:subfield>
+         <marc:subfield code="h">Quechuan (Kechuan) and Aymaran languages</marc:subfield>
+         <marc:subfield code="j">Quechuan (Kechuan) languages. Quechua (Kechua)</marc:subfield>
+         <marc:subfield code="t">Aymaran languages. Aymara</marc:subfield>
+      </marc:datafield>
+      <marc:datafield tag="685" ind1="2" ind2="1">
+         <marc:subfield code="t">Aymaran languages</marc:subfield>
+         <marc:subfield code="i">formerly</marc:subfield>
+         <marc:subfield code="z">6</marc:subfield>
+         <marc:subfield code="a">98323</marc:subfield>
+         <marc:subfield code="d">19960930</marc:subfield>
+         <marc:subfield code="2">21</marc:subfield>
+      </marc:datafield>
+      <marc:datafield tag="753" ind1=" " ind2=" ">
+         <marc:subfield code="a">Aymara language</marc:subfield>
+      </marc:datafield>
+      <marc:datafield tag="753" ind1=" " ind2=" ">
+         <marc:subfield code="a">Aymaran languages</marc:subfield>
+      </marc:datafield>
+   </marc:record>
+</marc:collection>

--- a/examples/ddc21en-6--9835.xml
+++ b/examples/ddc21en-6--9835.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<marc:collection xmlns:marc="http://www.loc.gov/MARC21/slim">
+   <marc:record>
+      <marc:leader>*****nw###22*****n##4500</marc:leader>
+      <marc:datafield tag="084" ind1="0" ind2="#">
+         <marc:subfield code="a">ddc</marc:subfield>
+         <marc:subfield code="c">21</marc:subfield>
+      </marc:datafield>
+      <marc:datafield tag="153" ind1=" " ind2=" ">
+         <marc:subfield code="z">6</marc:subfield>
+         <marc:subfield code="a">9835</marc:subfield>
+         <marc:subfield code="h">Languages</marc:subfield>
+         <marc:subfield code="h">Other languages</marc:subfield>
+         <marc:subfield code="h">South American native languages</marc:subfield>
+         <marc:subfield code="h">Quechuan (Kechuan), Aymaran, Tucanoan, Tupí, Arawakan languages</marc:subfield>
+         <marc:subfield code="j">Tucanoan languages</marc:subfield>
+      </marc:datafield>
+      <marc:datafield tag="680" ind1="0" ind2="#">
+         <marc:subfield code="i">Including Tucano</marc:subfield>
+      </marc:datafield>
+      <marc:datafield tag="685" ind1="0" ind2="3">
+         <marc:subfield code="i">expanded from</marc:subfield>
+         <marc:subfield code="z">6</marc:subfield>
+         <marc:subfield code="b">983</marc:subfield>
+         <marc:subfield code="d">19960930</marc:subfield>
+         <marc:subfield code="2">21</marc:subfield>
+      </marc:datafield>
+      <marc:datafield tag="753" ind1=" " ind2=" ">
+         <marc:subfield code="a">Tucano language</marc:subfield>
+      </marc:datafield>
+      <marc:datafield tag="753" ind1=" " ind2=" ">
+         <marc:subfield code="a">Tucanoan languages</marc:subfield>
+      </marc:datafield>
+      <marc:datafield tag="753" ind1=" " ind2=" ">
+         <marc:subfield code="a">Tukano language</marc:subfield>
+      </marc:datafield>
+      <marc:datafield tag="753" ind1=" " ind2=" ">
+         <marc:subfield code="a">Tukanoan languages</marc:subfield>
+      </marc:datafield>
+      <marc:datafield tag="753" ind1=" " ind2=" ">
+         <marc:subfield code="a">Yahuna language</marc:subfield>
+      </marc:datafield>
+   </marc:record>
+</marc:collection>

--- a/examples/ddc21en-6--9837.xml
+++ b/examples/ddc21en-6--9837.xml
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<marc:collection xmlns:marc="http://www.loc.gov/MARC21/slim">
+   <marc:record>
+      <marc:leader>*****nw###22*****n##4500</marc:leader>
+      <marc:datafield tag="084" ind1="0" ind2="#">
+         <marc:subfield code="a">ddc</marc:subfield>
+         <marc:subfield code="c">21</marc:subfield>
+      </marc:datafield>
+      <marc:datafield tag="153" ind1=" " ind2=" ">
+         <marc:subfield code="z">6</marc:subfield>
+         <marc:subfield code="a">9837</marc:subfield>
+         <marc:subfield code="h">Languages</marc:subfield>
+         <marc:subfield code="h">Other languages</marc:subfield>
+         <marc:subfield code="h">South American native languages</marc:subfield>
+         <marc:subfield code="h">Quechuan (Kechuan), Aymaran, Tucanoan, Tupí, Arawakan languages</marc:subfield>
+         <marc:subfield code="j">Jivaroan languages</marc:subfield>
+      </marc:datafield>
+      <marc:datafield tag="685" ind1="0" ind2="3">
+         <marc:subfield code="i">expanded from</marc:subfield>
+         <marc:subfield code="z">6</marc:subfield>
+         <marc:subfield code="b">983</marc:subfield>
+         <marc:subfield code="d">19960930</marc:subfield>
+         <marc:subfield code="2">21</marc:subfield>
+      </marc:datafield>
+      <marc:datafield tag="753" ind1=" " ind2=" ">
+         <marc:subfield code="a">Jivaran languages</marc:subfield>
+      </marc:datafield>
+      <marc:datafield tag="753" ind1=" " ind2=" ">
+         <marc:subfield code="a">Jivaroan languages</marc:subfield>
+      </marc:datafield>
+   </marc:record>
+   <marc:record>
+      <marc:leader>*****nw###22*****n##4500</marc:leader>
+      <marc:datafield tag="153" ind1=" " ind2=" ">
+         <marc:subfield code="z">6</marc:subfield>
+         <marc:subfield code="a">98</marc:subfield>
+         <marc:subfield code="h">Languages</marc:subfield>
+         <marc:subfield code="h">Other languages</marc:subfield>
+         <marc:subfield code="j">South American native languages</marc:subfield>
+      </marc:datafield>
+      <marc:datafield tag="553" ind1="1" ind2="#">
+         <marc:subfield code="w">j</marc:subfield>
+         <marc:subfield code="z">6</marc:subfield>
+         <marc:subfield code="a">9837</marc:subfield>
+         <marc:subfield code="h">Languages</marc:subfield>
+         <marc:subfield code="h">Other languages</marc:subfield>
+         <marc:subfield code="h">South American native languages</marc:subfield>
+         <marc:subfield code="h">Quechuan (Kechuan), Aymaran, Tucanoan, Tupí, Arawakan languages</marc:subfield>
+         <marc:subfield code="j">Jivaroan languages</marc:subfield>
+         <marc:subfield code="t">Yaruro</marc:subfield>
+      </marc:datafield>
+   </marc:record>
+   <marc:record>
+      <marc:leader>*****nw###22*****n##4500</marc:leader>
+      <marc:datafield tag="153" ind1=" " ind2=" ">
+         <marc:subfield code="z">6</marc:subfield>
+         <marc:subfield code="a">98372</marc:subfield>
+         <marc:subfield code="h">Languages</marc:subfield>
+         <marc:subfield code="h">Other languages</marc:subfield>
+         <marc:subfield code="h">South American native languages</marc:subfield>
+         <marc:subfield code="h">Quechuan (Kechuan), Aymaran, Tucanoan, Tupí, Arawakan languages</marc:subfield>
+         <marc:subfield code="j">Jivaroan languages</marc:subfield>
+         <marc:subfield code="j">Jivaro proper. Shuar</marc:subfield>
+      </marc:datafield>
+      <marc:datafield tag="553" ind1="1" ind2="#">
+         <marc:subfield code="w">jh</marc:subfield>
+         <marc:subfield code="z">6</marc:subfield>
+         <marc:subfield code="a">9837</marc:subfield>
+         <marc:subfield code="h">Languages</marc:subfield>
+         <marc:subfield code="h">Other languages</marc:subfield>
+         <marc:subfield code="h">South American native languages</marc:subfield>
+         <marc:subfield code="h">Quechuan (Kechuan), Aymaran, Tucanoan, Tupí, Arawakan languages</marc:subfield>
+         <marc:subfield code="j">Jivaroan languages</marc:subfield>
+         <marc:subfield code="t">Jivaro proper</marc:subfield>
+      </marc:datafield>
+   </marc:record>
+</marc:collection>

--- a/examples/ddc21en-6--98372.xml
+++ b/examples/ddc21en-6--98372.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<marc:collection xmlns:marc="http://www.loc.gov/MARC21/slim">
+   <marc:record>
+      <marc:leader>*****nw###22*****n##4500</marc:leader>
+      <marc:datafield tag="153" ind1=" " ind2=" ">
+         <marc:subfield code="z">6</marc:subfield>
+         <marc:subfield code="a">98372</marc:subfield>
+         <marc:subfield code="h">Languages</marc:subfield>
+         <marc:subfield code="h">Other languages</marc:subfield>
+         <marc:subfield code="h">South American native languages</marc:subfield>
+         <marc:subfield code="h">Quechuan (Kechuan), Aymaran, Tucanoan, Tupí, Arawakan languages</marc:subfield>
+         <marc:subfield code="j">Jivaroan languages</marc:subfield>
+         <marc:subfield code="j">Jivaro proper. Shuar</marc:subfield>
+      </marc:datafield>
+      <marc:datafield tag="553" ind1="1" ind2="#">
+         <marc:subfield code="w">jh</marc:subfield>
+         <marc:subfield code="z">6</marc:subfield>
+         <marc:subfield code="a">9837</marc:subfield>
+         <marc:subfield code="h">Languages</marc:subfield>
+         <marc:subfield code="h">Other languages</marc:subfield>
+         <marc:subfield code="h">South American native languages</marc:subfield>
+         <marc:subfield code="h">Quechuan (Kechuan), Aymaran, Tucanoan, Tupí, Arawakan languages</marc:subfield>
+         <marc:subfield code="j">Jivaroan languages</marc:subfield>
+         <marc:subfield code="t">Jivaro proper</marc:subfield>
+      </marc:datafield>
+      <marc:datafield tag="680" ind1="0" ind2="#">
+         <marc:subfield code="i">Including Huambisa</marc:subfield>
+      </marc:datafield>
+      <marc:datafield tag="685" ind1="0" ind2="3">
+         <marc:subfield code="i">expanded from</marc:subfield>
+         <marc:subfield code="z">6</marc:subfield>
+         <marc:subfield code="b">983</marc:subfield>
+         <marc:subfield code="d">19960930</marc:subfield>
+         <marc:subfield code="2">21</marc:subfield>
+      </marc:datafield>
+      <marc:datafield tag="753" ind1=" " ind2=" ">
+         <marc:subfield code="a">Huambisa language</marc:subfield>
+      </marc:datafield>
+      <marc:datafield tag="753" ind1=" " ind2=" ">
+         <marc:subfield code="a">Jivaro language</marc:subfield>
+      </marc:datafield>
+      <marc:datafield tag="753" ind1=" " ind2=" ">
+         <marc:subfield code="a">Jivaroa language</marc:subfield>
+      </marc:datafield>
+      <marc:datafield tag="753" ind1=" " ind2=" ">
+         <marc:subfield code="a">Shuar language</marc:subfield>
+      </marc:datafield>
+      <marc:datafield tag="753" ind1=" " ind2=" ">
+         <marc:subfield code="a">Shuara language</marc:subfield>
+      </marc:datafield>
+   </marc:record>
+</marc:collection>

--- a/examples/ddc21en-6--9838.xml
+++ b/examples/ddc21en-6--9838.xml
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<marc:collection xmlns:marc="http://www.loc.gov/MARC21/slim">
+   <marc:record>
+      <marc:leader>*****nw###22*****n##4500</marc:leader>
+      <marc:datafield tag="084" ind1="0" ind2="#">
+         <marc:subfield code="a">ddc</marc:subfield>
+         <marc:subfield code="c">21</marc:subfield>
+      </marc:datafield>
+      <marc:datafield tag="153" ind1=" " ind2=" ">
+         <marc:subfield code="z">6</marc:subfield>
+         <marc:subfield code="a">9838</marc:subfield>
+         <marc:subfield code="h">Languages</marc:subfield>
+         <marc:subfield code="h">Other languages</marc:subfield>
+         <marc:subfield code="h">South American native languages</marc:subfield>
+         <marc:subfield code="h">Quechuan (Kechuan), Aymaran, Tucanoan, Tupí, Arawakan languages</marc:subfield>
+         <marc:subfield code="j">Tupí languages</marc:subfield>
+      </marc:datafield>
+      <marc:datafield tag="680" ind1="0" ind2="#">
+         <marc:subfield code="i">Including Munduruku, Sirionó; Oyampi</marc:subfield>
+      </marc:datafield>
+      <marc:datafield tag="685" ind1="0" ind2="3">
+         <marc:subfield code="i">expanded from</marc:subfield>
+         <marc:subfield code="z">6</marc:subfield>
+         <marc:subfield code="b">983</marc:subfield>
+         <marc:subfield code="d">19960930</marc:subfield>
+         <marc:subfield code="2">21</marc:subfield>
+      </marc:datafield>
+      <marc:datafield tag="753" ind1=" " ind2=" ">
+         <marc:subfield code="a">Cocama language</marc:subfield>
+      </marc:datafield>
+      <marc:datafield tag="753" ind1=" " ind2=" ">
+         <marc:subfield code="a">Mundurucu language</marc:subfield>
+      </marc:datafield>
+      <marc:datafield tag="753" ind1=" " ind2=" ">
+         <marc:subfield code="a">Munduruku language</marc:subfield>
+      </marc:datafield>
+      <marc:datafield tag="753" ind1=" " ind2=" ">
+         <marc:subfield code="a">Oyampi language</marc:subfield>
+      </marc:datafield>
+      <marc:datafield tag="753" ind1=" " ind2=" ">
+         <marc:subfield code="a">Sirionó language</marc:subfield>
+      </marc:datafield>
+      <marc:datafield tag="753" ind1=" " ind2=" ">
+         <marc:subfield code="a">Tupí languages</marc:subfield>
+      </marc:datafield>
+      <marc:datafield tag="753" ind1=" " ind2=" ">
+         <marc:subfield code="a">Tupian languages</marc:subfield>
+      </marc:datafield>
+      <marc:datafield tag="753" ind1=" " ind2=" ">
+         <marc:subfield code="a">Wayampi language</marc:subfield>
+      </marc:datafield>
+      <marc:datafield tag="753" ind1=" " ind2=" ">
+         <marc:subfield code="a">Wayãpi language</marc:subfield>
+      </marc:datafield>
+   </marc:record>
+</marc:collection>

--- a/examples/ddc21en-6--98382.xml
+++ b/examples/ddc21en-6--98382.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<marc:collection xmlns:marc="http://www.loc.gov/MARC21/slim">
+   <marc:record>
+      <marc:leader>*****nw###22*****n##4500</marc:leader>
+      <marc:datafield tag="084" ind1="0" ind2="#">
+         <marc:subfield code="a">ddc</marc:subfield>
+         <marc:subfield code="c">21</marc:subfield>
+      </marc:datafield>
+      <marc:datafield tag="153" ind1=" " ind2=" ">
+         <marc:subfield code="z">6</marc:subfield>
+         <marc:subfield code="a">98382</marc:subfield>
+         <marc:subfield code="h">Languages</marc:subfield>
+         <marc:subfield code="h">Other languages</marc:subfield>
+         <marc:subfield code="h">South American native languages</marc:subfield>
+         <marc:subfield code="h">Quechuan (Kechuan), Aymaran, Tucanoan, Tupí, Arawakan languages</marc:subfield>
+         <marc:subfield code="h">Tupí languages</marc:subfield>
+         <marc:subfield code="j">Narrow Tupí group. Guaraní</marc:subfield>
+      </marc:datafield>
+      <marc:datafield tag="685" ind1="0" ind2="3">
+         <marc:subfield code="i">expanded from</marc:subfield>
+         <marc:subfield code="z">6</marc:subfield>
+         <marc:subfield code="b">983</marc:subfield>
+         <marc:subfield code="d">19960930</marc:subfield>
+         <marc:subfield code="2">21</marc:subfield>
+      </marc:datafield>
+      <marc:datafield tag="753" ind1=" " ind2=" ">
+         <marc:subfield code="a">Chiriguano language</marc:subfield>
+      </marc:datafield>
+      <marc:datafield tag="753" ind1=" " ind2=" ">
+         <marc:subfield code="a">Guaraní language</marc:subfield>
+      </marc:datafield>
+   </marc:record>
+</marc:collection>

--- a/examples/ddc21en-6--983829.xml
+++ b/examples/ddc21en-6--983829.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<marc:collection xmlns:marc="http://www.loc.gov/MARC21/slim">
+   <marc:record>
+      <marc:leader>*****nw###22*****n##4500</marc:leader>
+      <marc:datafield tag="084" ind1="0" ind2="#">
+         <marc:subfield code="a">ddc</marc:subfield>
+         <marc:subfield code="c">21</marc:subfield>
+      </marc:datafield>
+      <marc:datafield tag="153" ind1=" " ind2=" ">
+         <marc:subfield code="z">6</marc:subfield>
+         <marc:subfield code="a">983829</marc:subfield>
+         <marc:subfield code="h">Languages</marc:subfield>
+         <marc:subfield code="h">Other languages</marc:subfield>
+         <marc:subfield code="h">South American native languages</marc:subfield>
+         <marc:subfield code="h">Quechuan (Kechuan), Aymaran, Tucanoan, Tupí, Arawakan languages</marc:subfield>
+         <marc:subfield code="h">Tupí languages</marc:subfield>
+         <marc:subfield code="h">Narrow Tupí group. Guaraní</marc:subfield>
+         <marc:subfield code="j">Tupí (Nhengatu)</marc:subfield>
+      </marc:datafield>
+      <marc:datafield tag="685" ind1="0" ind2="3">
+         <marc:subfield code="i">expanded from</marc:subfield>
+         <marc:subfield code="z">6</marc:subfield>
+         <marc:subfield code="b">983</marc:subfield>
+         <marc:subfield code="d">19960930</marc:subfield>
+         <marc:subfield code="2">21</marc:subfield>
+      </marc:datafield>
+      <marc:datafield tag="753" ind1=" " ind2=" ">
+         <marc:subfield code="a">Neengatu language</marc:subfield>
+      </marc:datafield>
+      <marc:datafield tag="753" ind1=" " ind2=" ">
+         <marc:subfield code="a">Nheengatu language</marc:subfield>
+      </marc:datafield>
+      <marc:datafield tag="753" ind1=" " ind2=" ">
+         <marc:subfield code="a">Nhengatu language</marc:subfield>
+      </marc:datafield>
+      <marc:datafield tag="753" ind1=" " ind2=" ">
+         <marc:subfield code="a">Tupí language</marc:subfield>
+      </marc:datafield>
+   </marc:record>
+</marc:collection>

--- a/examples/ddc21en-6--9839.xml
+++ b/examples/ddc21en-6--9839.xml
@@ -1,0 +1,85 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<marc:collection xmlns:marc="http://www.loc.gov/MARC21/slim">
+   <marc:record>
+      <marc:leader>*****nw###22*****n##4500</marc:leader>
+      <marc:datafield tag="084" ind1="0" ind2="#">
+         <marc:subfield code="a">ddc</marc:subfield>
+         <marc:subfield code="c">21</marc:subfield>
+      </marc:datafield>
+      <marc:datafield tag="153" ind1=" " ind2=" ">
+         <marc:subfield code="z">6</marc:subfield>
+         <marc:subfield code="a">9839</marc:subfield>
+         <marc:subfield code="h">Languages</marc:subfield>
+         <marc:subfield code="h">Other languages</marc:subfield>
+         <marc:subfield code="h">South American native languages</marc:subfield>
+         <marc:subfield code="h">Quechuan (Kechuan), Aymaran, Tucanoan, Tupí, Arawakan languages</marc:subfield>
+         <marc:subfield code="j">Arawakan languages</marc:subfield>
+      </marc:datafield>
+      <marc:datafield tag="553" ind1="1" ind2="#">
+         <marc:subfield code="w">j</marc:subfield>
+         <marc:subfield code="z">6</marc:subfield>
+         <marc:subfield code="a">979</marc:subfield>
+         <marc:subfield code="h">Languages</marc:subfield>
+         <marc:subfield code="h">Other languages</marc:subfield>
+         <marc:subfield code="h">North American native languages</marc:subfield>
+         <marc:subfield code="j">Other North American languages</marc:subfield>
+         <marc:subfield code="t">comprehensive works on Arawakan languages</marc:subfield>
+      </marc:datafield>
+      <marc:datafield tag="685" ind1="0" ind2="3">
+         <marc:subfield code="i">expanded from</marc:subfield>
+         <marc:subfield code="z">6</marc:subfield>
+         <marc:subfield code="b">983</marc:subfield>
+         <marc:subfield code="d">19960930</marc:subfield>
+         <marc:subfield code="2">21</marc:subfield>
+      </marc:datafield>
+      <marc:datafield tag="753" ind1=" " ind2=" ">
+         <marc:subfield code="a">Arawak language</marc:subfield>
+      </marc:datafield>
+      <marc:datafield tag="753" ind1=" " ind2=" ">
+         <marc:subfield code="a">Arawakan languages</marc:subfield>
+      </marc:datafield>
+      <marc:datafield tag="753" ind1=" " ind2=" ">
+         <marc:subfield code="a">Arawakan languages—South America</marc:subfield>
+      </marc:datafield>
+      <marc:datafield tag="753" ind1=" " ind2=" ">
+         <marc:subfield code="a">Asheninca Campa language</marc:subfield>
+      </marc:datafield>
+      <marc:datafield tag="753" ind1=" " ind2=" ">
+         <marc:subfield code="a">Campa language</marc:subfield>
+      </marc:datafield>
+      <marc:datafield tag="753" ind1=" " ind2=" ">
+         <marc:subfield code="a">Goajiro language</marc:subfield>
+      </marc:datafield>
+      <marc:datafield tag="753" ind1=" " ind2=" ">
+         <marc:subfield code="a">Guajiro language</marc:subfield>
+      </marc:datafield>
+      <marc:datafield tag="753" ind1=" " ind2=" ">
+         <marc:subfield code="a">Maipuran languages</marc:subfield>
+      </marc:datafield>
+      <marc:datafield tag="753" ind1=" " ind2=" ">
+         <marc:subfield code="a">Mapura language</marc:subfield>
+      </marc:datafield>
+   </marc:record>
+   <marc:record>
+      <marc:leader>*****nw###22*****n##4500</marc:leader>
+      <marc:datafield tag="153" ind1=" " ind2=" ">
+         <marc:subfield code="z">6</marc:subfield>
+         <marc:subfield code="a">979</marc:subfield>
+         <marc:subfield code="h">Languages</marc:subfield>
+         <marc:subfield code="h">Other languages</marc:subfield>
+         <marc:subfield code="h">North American native languages</marc:subfield>
+         <marc:subfield code="j">Other North American languages</marc:subfield>
+      </marc:datafield>
+      <marc:datafield tag="553" ind1="1" ind2="#">
+         <marc:subfield code="w">k</marc:subfield>
+         <marc:subfield code="z">6</marc:subfield>
+         <marc:subfield code="a">9839</marc:subfield>
+         <marc:subfield code="h">Languages</marc:subfield>
+         <marc:subfield code="h">Other languages</marc:subfield>
+         <marc:subfield code="h">South American native languages</marc:subfield>
+         <marc:subfield code="h">Quechuan (Kechuan), Aymaran, Tucanoan, Tupí, Arawakan languages</marc:subfield>
+         <marc:subfield code="j">Arawakan languages</marc:subfield>
+         <marc:subfield code="t">Arawakan languages of Central America and West Indies</marc:subfield>
+      </marc:datafield>
+   </marc:record>
+</marc:collection>

--- a/examples/ddc21en-6--984.xml
+++ b/examples/ddc21en-6--984.xml
@@ -1,0 +1,95 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<marc:collection xmlns:marc="http://www.loc.gov/MARC21/slim">
+   <marc:record>
+      <marc:leader>*****nw###22*****n##4500</marc:leader>
+      <marc:datafield tag="084" ind1="0" ind2="#">
+         <marc:subfield code="a">ddc</marc:subfield>
+         <marc:subfield code="c">21</marc:subfield>
+      </marc:datafield>
+      <marc:datafield tag="153" ind1=" " ind2=" ">
+         <marc:subfield code="z">6</marc:subfield>
+         <marc:subfield code="a">984</marc:subfield>
+         <marc:subfield code="h">Languages</marc:subfield>
+         <marc:subfield code="h">Other languages</marc:subfield>
+         <marc:subfield code="h">South American native languages</marc:subfield>
+         <marc:subfield code="j">Carib, Macro-Gê, Nambiquaran, Panoan languages</marc:subfield>
+      </marc:datafield>
+      <marc:datafield tag="753" ind1=" " ind2=" ">
+         <marc:subfield code="a">Akwe-Shavante language</marc:subfield>
+      </marc:datafield>
+      <marc:datafield tag="753" ind1=" " ind2=" ">
+         <marc:subfield code="a">Canella language</marc:subfield>
+      </marc:datafield>
+      <marc:datafield tag="753" ind1=" " ind2=" ">
+         <marc:subfield code="a">Caraja language</marc:subfield>
+      </marc:datafield>
+      <marc:datafield tag="753" ind1=" " ind2=" ">
+         <marc:subfield code="a">Carajó language</marc:subfield>
+      </marc:datafield>
+      <marc:datafield tag="753" ind1=" " ind2=" ">
+         <marc:subfield code="a">Carib language</marc:subfield>
+      </marc:datafield>
+      <marc:datafield tag="753" ind1=" " ind2=" ">
+         <marc:subfield code="a">Cariban languages</marc:subfield>
+      </marc:datafield>
+      <marc:datafield tag="753" ind1=" " ind2=" ">
+         <marc:subfield code="a">Cashinawa language</marc:subfield>
+      </marc:datafield>
+      <marc:datafield tag="753" ind1=" " ind2=" ">
+         <marc:subfield code="a">Catuquina language (Panoan)</marc:subfield>
+      </marc:datafield>
+      <marc:datafield tag="753" ind1=" " ind2=" ">
+         <marc:subfield code="a">Cayapó language</marc:subfield>
+      </marc:datafield>
+      <marc:datafield tag="753" ind1=" " ind2=" ">
+         <marc:subfield code="a">Gê language</marc:subfield>
+      </marc:datafield>
+      <marc:datafield tag="753" ind1=" " ind2=" ">
+         <marc:subfield code="a">Gê-Pano-Carib languages</marc:subfield>
+      </marc:datafield>
+      <marc:datafield tag="753" ind1=" " ind2=" ">
+         <marc:subfield code="a">Kayapó language</marc:subfield>
+      </marc:datafield>
+      <marc:datafield tag="753" ind1=" " ind2=" ">
+         <marc:subfield code="a">Macro-Gê languages</marc:subfield>
+      </marc:datafield>
+      <marc:datafield tag="753" ind1=" " ind2=" ">
+         <marc:subfield code="a">Nambicuara language</marc:subfield>
+      </marc:datafield>
+      <marc:datafield tag="753" ind1=" " ind2=" ">
+         <marc:subfield code="a">Nambikuara language</marc:subfield>
+      </marc:datafield>
+      <marc:datafield tag="753" ind1=" " ind2=" ">
+         <marc:subfield code="a">Nambiquaran languages</marc:subfield>
+      </marc:datafield>
+      <marc:datafield tag="753" ind1=" " ind2=" ">
+         <marc:subfield code="a">Panoan languages</marc:subfield>
+      </marc:datafield>
+      <marc:datafield tag="753" ind1=" " ind2=" ">
+         <marc:subfield code="a">Pemón language</marc:subfield>
+      </marc:datafield>
+      <marc:datafield tag="753" ind1=" " ind2=" ">
+         <marc:subfield code="a">Xavante language</marc:subfield>
+      </marc:datafield>
+   </marc:record>
+   <marc:record>
+      <marc:leader>*****nw###22*****n##4500</marc:leader>
+      <marc:datafield tag="153" ind1=" " ind2=" ">
+         <marc:subfield code="z">6</marc:subfield>
+         <marc:subfield code="a">98</marc:subfield>
+         <marc:subfield code="h">Languages</marc:subfield>
+         <marc:subfield code="h">Other languages</marc:subfield>
+         <marc:subfield code="j">South American native languages</marc:subfield>
+      </marc:datafield>
+      <marc:datafield tag="553" ind1="1" ind2="#">
+         <marc:subfield code="w">j</marc:subfield>
+         <marc:subfield code="z">6</marc:subfield>
+         <marc:subfield code="a">984</marc:subfield>
+         <marc:subfield code="h">Languages</marc:subfield>
+         <marc:subfield code="h">Other languages</marc:subfield>
+         <marc:subfield code="h">South American native languages</marc:subfield>
+         <marc:subfield code="j">Carib, Macro-Gê, Nambiquaran, Panoan languages</marc:subfield>
+         <marc:subfield code="t">Hixkaryana, Mataco-Guaicuru, Tacanan, Witotoan languages</marc:subfield>
+      </marc:datafield>
+   </marc:record>
+</marc:collection>


### PR DESCRIPTION
I converted official examples from https://www.loc.gov/marc/classification/examples.html to MARCXML. They are from the 21st edition and English, so the conversion assigns wrong language tags. Once this is fixed we could use the examples for automated testing. I checked that they at least result in no error:

    for file in examples/ddc21en*; do mc2skos $file out.skos http://example.org/ --scheme http://example.org/; done