### PR TITLE
Use examples as test suite

### DIFF
--- a/examples/ddc21en-003.3.ttl
+++ b/examples/ddc21en-003.3.ttl
@@ -1,0 +1,10 @@
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix xml: <http://www.w3.org/XML/1998/namespace> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+<http://test/003.3> a skos:Concept ;
+    skos:notation "003.3" ;
+    skos:prefLabel "Computer modeling and simulation"@en .
+

--- a/examples/ddc21en-003.5.ttl
+++ b/examples/ddc21en-003.5.ttl
@@ -1,0 +1,18 @@
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix xml: <http://www.w3.org/XML/1998/namespace> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+<http://test/003.5> a skos:Concept ;
+    skos:notation "003.5" ;
+    skos:prefLabel "Theory of communication and control"@en .
+
+<http://test/006.3> a skos:Concept ;
+    skos:notation "006.3" ;
+    skos:prefLabel "Artificial intelligence"@en .
+
+<http://test/302.2> a skos:Concept ;
+    skos:notation "302.2" ;
+    skos:prefLabel "Communication"@en .
+

--- a/examples/ddc21en-003.52.ttl
+++ b/examples/ddc21en-003.52.ttl
@@ -1,0 +1,26 @@
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix xml: <http://www.w3.org/XML/1998/namespace> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+<http://test/003.52> a skos:Concept ;
+    skos:notation "003.52" ;
+    skos:prefLabel "Perception theory"@en .
+
+<http://test/006.37> a skos:Concept ;
+    skos:notation "006.37" ;
+    skos:prefLabel "Computer vision"@en .
+
+<http://test/006.4> a skos:Concept ;
+    skos:notation "006.4" ;
+    skos:prefLabel "Computer pattern recognition"@en .
+
+<http://test/153.7> a skos:Concept ;
+    skos:notation "153.7" ;
+    skos:prefLabel "Perceptual processes"@en .
+
+<http://test/573.87> a skos:Concept ;
+    skos:notation "573.87" ;
+    skos:prefLabel "Sense organs"@en .
+

--- a/examples/ddc21en-003.54.ttl
+++ b/examples/ddc21en-003.54.ttl
@@ -1,0 +1,10 @@
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix xml: <http://www.w3.org/XML/1998/namespace> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+<http://test/003.54> a skos:Concept ;
+    skos:notation "003.54" ;
+    skos:prefLabel "Information theory"@en .
+

--- a/examples/ddc21en-003.56.ttl
+++ b/examples/ddc21en-003.56.ttl
@@ -1,0 +1,22 @@
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix xml: <http://www.w3.org/XML/1998/namespace> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+<http://test/003.56> a skos:Concept ;
+    skos:notation "003.56" ;
+    skos:prefLabel "Decision theory"@en .
+
+<http://test/153.83> a skos:Concept ;
+    skos:notation "153.83" ;
+    skos:prefLabel "Choice and decision"@en .
+
+<http://test/511.65> a skos:Concept ;
+    skos:notation "511.65" ;
+    skos:prefLabel "Choice"@en .
+
+<http://test/658.40301> a skos:Concept ;
+    skos:notation "658.40301" ;
+    skos:prefLabel "Philosophy and theory of decision making"@en .
+

--- a/examples/ddc21en-003.7.ttl
+++ b/examples/ddc21en-003.7.ttl
@@ -1,0 +1,14 @@
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix xml: <http://www.w3.org/XML/1998/namespace> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+<http://test/003.7> a skos:Concept ;
+    skos:notation "003.7" ;
+    skos:prefLabel "Kinds of systems"@en .
+
+<http://test/003.8> a skos:Concept ;
+    skos:notation "003.8" ;
+    skos:prefLabel "Systems distinguished in relation to time"@en .
+

--- a/examples/ddc21en-003.71.ttl
+++ b/examples/ddc21en-003.71.ttl
@@ -1,0 +1,10 @@
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix xml: <http://www.w3.org/XML/1998/namespace> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+<http://test/003.71> a skos:Concept ;
+    skos:notation "003.71" ;
+    skos:prefLabel "Large-scale systems"@en .
+

--- a/examples/ddc21en-6--98.ttl
+++ b/examples/ddc21en-6--98.ttl
@@ -1,0 +1,10 @@
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix xml: <http://www.w3.org/XML/1998/namespace> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+<http://test/6--98> a skos:Concept ;
+    skos:notation "T6--98" ;
+    skos:prefLabel "South American native languages"@en .
+

--- a/examples/ddc21en-6--982.ttl
+++ b/examples/ddc21en-6--982.ttl
@@ -1,0 +1,18 @@
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix xml: <http://www.w3.org/XML/1998/namespace> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+<http://test/6--978> a skos:Concept ;
+    skos:notation "T6--978" ;
+    skos:prefLabel "Chibchan languages of North American, Misumalpan languages"@en .
+
+<http://test/6--98> a skos:Concept ;
+    skos:notation "T6--98" ;
+    skos:prefLabel "South American native languages"@en .
+
+<http://test/6--982> a skos:Concept ;
+    skos:notation "T6--982" ;
+    skos:prefLabel "Chibchan and Paezan languages"@en .
+

--- a/examples/ddc21en-6--983.ttl
+++ b/examples/ddc21en-6--983.ttl
@@ -1,0 +1,10 @@
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix xml: <http://www.w3.org/XML/1998/namespace> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+<http://test/6--983> a skos:Concept ;
+    skos:notation "T6--983" ;
+    skos:prefLabel "Quechuan (Kechuan), Aymaran, Tucanoan, Tupí, Arawakan languages"@en .
+

--- a/examples/ddc21en-6--9832.ttl
+++ b/examples/ddc21en-6--9832.ttl
@@ -1,0 +1,10 @@
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix xml: <http://www.w3.org/XML/1998/namespace> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+<http://test/6--9832> a skos:Concept ;
+    skos:notation "T6--9832" ;
+    skos:prefLabel "Quechuan (Kechuan) and Aymaran languages"@en .
+

--- a/examples/ddc21en-6--98323.ttl
+++ b/examples/ddc21en-6--98323.ttl
@@ -1,0 +1,10 @@
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix xml: <http://www.w3.org/XML/1998/namespace> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+<http://test/6--98323> a skos:Concept ;
+    skos:notation "T6--98323" ;
+    skos:prefLabel "Quechuan (Kechuan) languages. Quechua (Kechua)"@en .
+

--- a/examples/ddc21en-6--98324.ttl
+++ b/examples/ddc21en-6--98324.ttl
@@ -1,0 +1,10 @@
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix xml: <http://www.w3.org/XML/1998/namespace> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+<http://test/6--98324> a skos:Concept ;
+    skos:notation "T6--98324" ;
+    skos:prefLabel "Aymaran languages. Aymara"@en .
+

--- a/examples/ddc21en-6--9835.ttl
+++ b/examples/ddc21en-6--9835.ttl
@@ -1,0 +1,10 @@
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix xml: <http://www.w3.org/XML/1998/namespace> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+<http://test/6--9835> a skos:Concept ;
+    skos:notation "T6--9835" ;
+    skos:prefLabel "Tucanoan languages"@en .
+

--- a/examples/ddc21en-6--9837.ttl
+++ b/examples/ddc21en-6--9837.ttl
@@ -1,0 +1,18 @@
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix xml: <http://www.w3.org/XML/1998/namespace> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+<http://test/6--98> a skos:Concept ;
+    skos:notation "T6--98" ;
+    skos:prefLabel "South American native languages"@en .
+
+<http://test/6--9837> a skos:Concept ;
+    skos:notation "T6--9837" ;
+    skos:prefLabel "Jivaroan languages"@en .
+
+<http://test/6--98372> a skos:Concept ;
+    skos:notation "T6--98372" ;
+    skos:prefLabel "Jivaroan languages"@en .
+

--- a/examples/ddc21en-6--98372.ttl
+++ b/examples/ddc21en-6--98372.ttl
@@ -1,0 +1,10 @@
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix xml: <http://www.w3.org/XML/1998/namespace> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+<http://test/6--98372> a skos:Concept ;
+    skos:notation "T6--98372" ;
+    skos:prefLabel "Jivaroan languages"@en .
+

--- a/examples/ddc21en-6--9838.ttl
+++ b/examples/ddc21en-6--9838.ttl
@@ -1,0 +1,10 @@
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix xml: <http://www.w3.org/XML/1998/namespace> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+<http://test/6--9838> a skos:Concept ;
+    skos:notation "T6--9838" ;
+    skos:prefLabel "Tupí languages"@en .
+

--- a/examples/ddc21en-6--98382.ttl
+++ b/examples/ddc21en-6--98382.ttl
@@ -1,0 +1,10 @@
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix xml: <http://www.w3.org/XML/1998/namespace> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+<http://test/6--98382> a skos:Concept ;
+    skos:notation "T6--98382" ;
+    skos:prefLabel "Narrow Tupí group. Guaraní"@en .
+

--- a/examples/ddc21en-6--983829.ttl
+++ b/examples/ddc21en-6--983829.ttl
@@ -1,0 +1,10 @@
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix xml: <http://www.w3.org/XML/1998/namespace> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+<http://test/6--983829> a skos:Concept ;
+    skos:notation "T6--983829" ;
+    skos:prefLabel "Tupí (Nhengatu)"@en .
+

--- a/examples/ddc21en-6--9839.ttl
+++ b/examples/ddc21en-6--9839.ttl
@@ -1,0 +1,14 @@
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix xml: <http://www.w3.org/XML/1998/namespace> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+<http://test/6--979> a skos:Concept ;
+    skos:notation "T6--979" ;
+    skos:prefLabel "Other North American languages"@en .
+
+<http://test/6--9839> a skos:Concept ;
+    skos:notation "T6--9839" ;
+    skos:prefLabel "Arawakan languages"@en .
+

--- a/examples/ddc21en-6--984.ttl
+++ b/examples/ddc21en-6--984.ttl
@@ -1,0 +1,14 @@
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix xml: <http://www.w3.org/XML/1998/namespace> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+<http://test/6--98> a skos:Concept ;
+    skos:notation "T6--98" ;
+    skos:prefLabel "South American native languages"@en .
+
+<http://test/6--984> a skos:Concept ;
+    skos:notation "T6--984" ;
+    skos:prefLabel "Carib, Macro-Gê, Nambiquaran, Panoan languages"@en .
+

--- a/examples/ddc23de-001.ttl
+++ b/examples/ddc23de-001.ttl
@@ -1,0 +1,11 @@
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix xml: <http://www.w3.org/XML/1998/namespace> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+<http://test/001> a skos:Concept ;
+    skos:broader <http://test/00> ;
+    skos:notation "001" ;
+    skos:prefLabel "Wissen"@de .
+

--- a/examples/ddc23de-001.xml
+++ b/examples/ddc23de-001.xml
@@ -1,0 +1,114 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<marc:collection xmlns:marc="http://www.loc.gov/MARC21/slim">
+<marc:record>
+  <marc:leader>00000nw  a2200000n  4500</marc:leader>
+  <marc:controlfield tag="001">e957a697-9369-3496-85af-bd067229b32d</marc:controlfield>
+  <marc:controlfield tag="003">DE-101</marc:controlfield>
+  <marc:controlfield tag="005">20110728111208.0</marc:controlfield>
+  <marc:controlfield tag="008">000202aaaabaaa</marc:controlfield>
+  <marc:datafield tag="035" ind2=" " ind1=" ">
+    <marc:subfield code="a">ocd00116591</marc:subfield>
+  </marc:datafield>
+  <marc:datafield tag="040" ind2=" " ind1=" ">
+    <marc:subfield code="a">OCoLC-D</marc:subfield>
+    <marc:subfield code="b">ger</marc:subfield>
+    <marc:subfield code="c">DE-101</marc:subfield>
+    <marc:subfield code="d">DE-101</marc:subfield>
+  </marc:datafield>
+  <marc:datafield tag="084" ind2=" " ind1="0">
+    <marc:subfield code="a">ddc</marc:subfield>
+    <marc:subfield code="c">23de</marc:subfield>
+    <marc:subfield code="e">ger</marc:subfield>
+  </marc:datafield>
+  <marc:datafield tag="153" ind2=" " ind1=" ">
+    <marc:subfield code="a">001</marc:subfield>
+    <marc:subfield code="e">00</marc:subfield>
+    <marc:subfield code="j">Wissen</marc:subfield>
+    <marc:subfield code="9">ess=en</marc:subfield>
+    <marc:subfield code="9">ess=eh</marc:subfield>
+  </marc:datafield>
+  <marc:datafield tag="680" ind2=" " ind1="1">
+    <marc:subfield code="i">Darstellung und kritische Bewertung intellektueller, geistiger Aktivität im Allgemeinen</marc:subfield>
+    <marc:subfield code="9">ess=nsc</marc:subfield>
+  </marc:datafield>
+  <marc:datafield tag="680" ind2=" " ind1="0">
+    <marc:subfield code="i">Einschließlich:</marc:subfield>
+    <marc:subfield code="t">fächerübergreifende Werke über Berater</marc:subfield>
+    <marc:subfield code="9">ess=nin</marc:subfield>
+  </marc:datafield>
+  <marc:datafield tag="680" ind2=" " ind1="1">
+    <marc:subfield code="i">Hier auch:</marc:subfield>
+    <marc:subfield code="t">Diskussion von Ideen aus vielen Gebieten, fächerübergreifender Ansatz zum Wissensbegriff</marc:subfield>
+    <marc:subfield code="9">ess=nch</marc:subfield>
+  </marc:datafield>
+  <marc:datafield tag="253" ind2=" " ind1="2">
+    <marc:subfield code="i">Klassifiziere</marc:subfield>
+    <marc:subfield code="t">Epistemologie</marc:subfield>
+    <marc:subfield code="i">in</marc:subfield>
+    <marc:subfield code="a">121</marc:subfield>
+    <marc:subfield code="9">ess=nce</marc:subfield>
+  </marc:datafield>
+  <marc:datafield tag="253" ind2=" " ind1="2">
+    <marc:subfield code="i">Klassifiziere</marc:subfield>
+    <marc:subfield code="t">eine Zusammenstellung von Wissen in einer bestimmten Form</marc:subfield>
+    <marc:subfield code="i">bei der Form, z.B.</marc:subfield>
+    <marc:subfield code="t">Enzyklopädien</marc:subfield>
+    <marc:subfield code="e">030</marc:subfield>
+    <marc:subfield code="9">ess=ncw</marc:subfield>
+  </marc:datafield>
+  <marc:datafield tag="253" ind2=" " ind1="0">
+    <marc:subfield code="i">Für</marc:subfield>
+    <marc:subfield code="t">Berater oder für den Einsatz von Beratern in einem bestimmten Thema</marc:subfield>
+    <marc:subfield code="i">siehe das Thema, z.B.</marc:subfield>
+    <marc:subfield code="t">Bibliotheksberater</marc:subfield>
+    <marc:subfield code="e">023.2</marc:subfield>
+    <marc:subfield code="i">, technische Berater</marc:subfield>
+    <marc:subfield code="e">620</marc:subfield>
+    <marc:subfield code="i">, Einsatz von Beratern im Management</marc:subfield>
+    <marc:subfield code="e">658.46</marc:subfield>
+    <marc:subfield code="9">ess=nsw</marc:subfield>
+  </marc:datafield>
+  <marc:datafield tag="684" ind2=" " ind1="2">
+    <marc:subfield code="i">Siehe Praxishilfe bei</marc:subfield>
+    <marc:subfield code="a">500</marc:subfield>
+    <marc:subfield code="i">vs.</marc:subfield>
+    <marc:subfield code="a">001</marc:subfield>
+    <marc:subfield code="9">ess=nsm</marc:subfield>
+  </marc:datafield>
+  <marc:datafield tag="750" ind2="7" ind1=" ">
+    <marc:subfield code="a">Berater</marc:subfield>
+    <marc:subfield code="2">ddcri</marc:subfield>
+    <marc:subfield code="9">ps=PE</marc:subfield>
+  </marc:datafield>
+  <marc:datafield tag="750" ind2="7" ind1=" ">
+    <marc:subfield code="a">Gutachter</marc:subfield>
+    <marc:subfield code="2">ddcri</marc:subfield>
+    <marc:subfield code="9">ps=PE</marc:subfield>
+  </marc:datafield>
+  <marc:datafield tag="750" ind2="7" ind1=" ">
+    <marc:subfield code="a">Experten</marc:subfield>
+    <marc:subfield code="2">ddcri</marc:subfield>
+    <marc:subfield code="9">ps=PE</marc:subfield>
+  </marc:datafield>
+  <marc:datafield tag="750" ind2="7" ind1=" ">
+    <marc:subfield code="a">Fächerübergreifender Ansatz zum Wissensbegriff</marc:subfield>
+    <marc:subfield code="2">ddcri</marc:subfield>
+    <marc:subfield code="9">ps=PE</marc:subfield>
+  </marc:datafield>
+  <marc:datafield tag="750" ind2="7" ind1=" ">
+    <marc:subfield code="a">Wissen</marc:subfield>
+    <marc:subfield code="2">ddcri</marc:subfield>
+    <marc:subfield code="9">ps=PE</marc:subfield>
+  </marc:datafield>
+  <marc:datafield tag="750" ind2="7" ind1=" ">
+    <marc:subfield code="a">Wissensbegriff</marc:subfield>
+    <marc:subfield code="2">ddcri</marc:subfield>
+    <marc:subfield code="9">ps=PE</marc:subfield>
+  </marc:datafield>
+  <marc:datafield tag="750" ind2="7" ind1=" ">
+    <marc:subfield code="a">Wissenschaften (Wissensbegriff)</marc:subfield>
+    <marc:subfield code="2">ddcri</marc:subfield>
+    <marc:subfield code="9">ps=PE</marc:subfield>
+  </marc:datafield>
+</marc:record>
+</marc:collection>

--- a/tests/test_process_examples.py
+++ b/tests/test_process_examples.py
@@ -1,0 +1,64 @@
+# encoding=utf-8
+import unittest
+import pytest
+import os
+import re
+from lxml import etree
+from mc2skos.mc2skos import process_record
+from rdflib.namespace import RDF, SKOS, Namespace
+from rdflib import URIRef, Literal, Graph
+
+
+def get_records(marcfile):
+    for _, record in etree.iterparse(marcfile, tag='{http://www.loc.gov/MARC21/slim}record'):
+        yield record
+        record.clear()
+
+
+class TestProcessExamples(unittest.TestCase):
+
+    def setUp(self):
+        self.graph = Graph()
+        self.nsmap = {'mx': 'http://www.loc.gov/MARC21/slim'}
+        self.ns = Namespace('http://test/')
+
+    def testExamples(self):
+        pattern = re.compile('^(ddc([0-9][0-9])([a-z]+)-([0-9.]+|([0-9])--([0-9.]+)))\.xml$')
+
+        for marcfile in os.listdir('examples'):
+            match = pattern.match(marcfile)
+            if not match:
+                continue
+
+            name = match.group(1)
+            notation = match.group(4)
+            table = match.group(5)
+
+            marcfile = 'examples/' + marcfile
+            # print marcfile
+            rdffile = 'examples/' + name + '.ttl'
+
+            graph = Graph()
+            for record in get_records(marcfile):
+                process_record(graph, record, self.nsmap, self.ns, None, None)
+            # print graph.serialize(format='turtle')
+
+            expect = Graph()
+            uri = URIRef(u'http://test/' + notation)
+            expect.add((uri, RDF.type, SKOS.Concept))
+            if table:
+                notation = "T" + notation
+            expect.add((uri, SKOS.notation, Literal(notation)))
+
+            if os.path.isfile(rdffile):
+                expect.parse(rdffile, format='turtle')
+            else:
+                if len(graph) > 0:
+                    graph.namespace_manager.bind('skos', URIRef('http://www.w3.org/2004/02/skos/core#'))
+                    graph.serialize(destination=rdffile, format='turtle')
+
+            for triple in expect:
+                assert triple in graph
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
test_process_examples.py reads all XML example files, transforms each to
RDF and compares whether the resulting graph contains expected triples
given in a corresponding Turtle file.

The current version does not include number spans. Python code may
benefit from some cleanup, it's my first attempt in this language.