### PR TITLE
Add example of Basisklassifikation (#13)

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -25,7 +25,7 @@ records (serialized as MARCXML) to
 
 Developed to support the
 project "`Felles terminologi for klassifikasjon med Dewey <https://www.duo.uio.no/handle/10852/39834>`_",
-it has only been tested with Dewey Decimal Classification (DDC) records.
+for converting Dewey Decimal Classification (DDC) records.
 `Issues <https://github.com/scriptotek/mc2skos/issues>`_ and
 suggestions for generalizations and improvements are welcome!
 
@@ -59,39 +59,52 @@ Usage
 
 .. code-block:: console
 
-    mc2skos infile.xml outfile.ttl
+    mc2skos infile.xml outfile.ttl      # from file to file
+    mc2skos infile.xml > outfile.ttl    # from file to standard output
 
 Run ``mc2skos --help`` or ``mc2skos -h`` for options.
 
 URIs
 ====
 
-For records with ``084 $a == "ddc"``, URIs are generated on the form
-``http://dewey.info/{collection}/{object}/e{edition}/``, where
-``{collection}`` is "class", "table" or "scheme", and ``{edition}`` is
-taken from ``084 $c`` (with language code stripped).
+Concept URIs are generated from an URI template specified with option
+``--uri``.  The following template parameters are recognized:
+
+* ``{collection}`` is "class", "table" or "scheme"
+* ``{object}`` is ... or table number or ??????????
+* ``{edition}`` is taken from ``084 $c`` (with language code stripped)
+
+The following default URI template are used for known concept scheme
+identifiers in ``084 $a``:
+
+* ``ddc``: ``http://dewey.info/{collection}/{object}/e{edition}/`` (DDC)
+* ``bkl``: ``http://uri.gbv.de/terminology/bk/{object}`` (Basisklassifikation)
+
+To add ``skos:inScheme`` statements to all records, an URI template must be
+specified with option ``--scheme`` or it is derived from a known default
+template.
+
+To add an additional ``skos:inScheme`` statement to table records, an URI
+template must be specified with option ``--table_scheme`` or it is derived from
+a known default template.
+
+The following example is generated from a DDC table record:
 
 .. code-block:: turtle
 
     <http://dewey.info/class/6--982/e21/> a skos:Concept ;
         skos:inScheme <http://dewey.info/scheme/edition/e21/>,
-            <http://dewey.info/table/6/e21/> ;
+                      <http://dewey.info/table/6/e21/> ;
         skos:notation "T6--982" ;
         skos:prefLabel "Chibchan and Paezan languages"@en .
 
-To override this, you can specify ``--uri`` to set a URI template for classes and table record,
-``--scheme`` to set a URI to be used with ``skos:inScheme`` for all records, and ``--table_scheme``
-to set a URI template to be used with ``skos:inScheme`` for table records. Note that
-if ``--uri`` is specified, but not ``--scheme``, no ``skos:inScheme`` will be added. Same goes
-with ``--table_scheme``.
 
 Mapping schema
 ==============
 
-Only a small part of the MARC21 Classification
-data model is converted, and the conversion follows a rather
-pragmatic approach, exemplified by the mapping of the 7XX fields
-to skos:altLabel.
+Only a small part of the MARC21 Classification data model is converted, and the
+conversion follows a rather pragmatic approach, exemplified by the mapping of
+the 7XX fields to skos:altLabel.
 
 ==========================================================  =====================================
 MARC21XML                                                    RDF

--- a/examples/bk-54.65.ttl
+++ b/examples/bk-54.65.ttl
@@ -1,0 +1,16 @@
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix xml: <http://www.w3.org/XML/1998/namespace> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+<http://uri.gbv.de/terminology/bk/54.65> a skos:Concept ;
+    skos:altLabel "Datenbankanbindung"@de,
+        "Skriptsprachen"@de,
+        "Web engineering"@de,
+        "Webdesign"@de ;
+    skos:broader <http://uri.gbv.de/terminology/bk/54> ;
+    skos:inScheme <http://uri.gbv.de/terminology/bk/> ;
+    skos:notation "54.65" ;
+    skos:prefLabel "Webentwicklung. Webanwendungen"@de .
+

--- a/examples/bk-54.65.xml
+++ b/examples/bk-54.65.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<marc:collection xmlns:marc="http://www.loc.gov/MARC21/slim">
+  <marc:record>
+    <marc:leader>00515nw aa2200181n  4500</marc:leader>
+    <marc:controlfield tag="001">475288998</marc:controlfield>
+    <marc:controlfield tag="003">DE-601</marc:controlfield>
+    <marc:controlfield tag="005">20120629220042.0</marc:controlfield>
+    <marc:controlfield tag="008">041217ananaana</marc:controlfield>
+    <marc:datafield tag="040" ind1=" " ind2=" ">
+      <marc:subfield code="a">DE-601</marc:subfield>
+      <marc:subfield code="b">ger</marc:subfield>
+    </marc:datafield>
+    <marc:datafield tag="084" ind1="0" ind2=" ">
+      <marc:subfield code="a">bkl</marc:subfield>
+      <marc:subfield code="e">ger</marc:subfield>
+      <marc:subfield code="q">DE-601</marc:subfield>
+    </marc:datafield>
+    <marc:datafield tag="153" ind1=" " ind2=" ">
+      <marc:subfield code="a">54.65</marc:subfield>
+      <marc:subfield code="e">54</marc:subfield>
+      <marc:subfield code="j">Webentwicklung. Webanwendungen</marc:subfield>
+    </marc:datafield>
+    <marc:datafield tag="680" ind1="0" ind2=" ">
+      <marc:subfield code="i">Gestaltung von Weboberflächen und Navigationsstrukturen, Entwurf und Programmierung internetbasierter Endnutzerdienste</marc:subfield>
+    </marc:datafield>
+    <marc:datafield tag="750" ind1=" " ind2="4">
+      <marc:subfield code="a">Webdesign</marc:subfield>
+    </marc:datafield>
+    <marc:datafield tag="750" ind1=" " ind2="4">
+      <marc:subfield code="a">Datenbankanbindung</marc:subfield>
+    </marc:datafield>
+    <marc:datafield tag="750" ind1=" " ind2="4">
+      <marc:subfield code="a">Skriptsprachen</marc:subfield>
+    </marc:datafield>
+    <marc:datafield tag="753" ind1=" " ind2=" ">
+      <marc:subfield code="a">Web engineering</marc:subfield>
+    </marc:datafield>
+  </marc:record>
+</marc:collection>

--- a/mc2skos/mc2skos.py
+++ b/mc2skos/mc2skos.py
@@ -711,11 +711,12 @@ def main():
 
     n = 0
     for record in get_records(in_file):
+        n += 1
         try:
             process_record(graph, record, **options)
         except InvalidRecordError as e:
-            # logger.debug('Ignoring invalid record: %s', e)
-            pass  # ignore
+            logger.debug('Ignoring record %d: %s', n, e)
+            pass
 
     if not graph:
         logger.warn('RDF result is empty!')

--- a/mc2skos/mc2skos.py
+++ b/mc2skos/mc2skos.py
@@ -724,6 +724,10 @@ def main():
             # logger.debug('Ignoring invalid record: %s', e)
             pass  # ignore
 
+    if not graph:
+        logger.warn('RDF result is empty!')
+        return
+
     # @TODO: Perhaps use OrderedTurtleSerializer if available, but fallback to default Turtle serializer if not?
     s = OrderedTurtleSerializer(graph)
 

--- a/mc2skos/mc2skos.py
+++ b/mc2skos/mc2skos.py
@@ -37,6 +37,9 @@ counts = {}
 default_uri_templates = {
     "ddc": {
         "uri": "http://dewey.info/{collection}/{object}/e{edition}/"
+    },
+    "bkl": {
+        "uri": "http://uri.gbv.de/terminology/bk/{object}"
     }
 }
 
@@ -205,8 +208,10 @@ class Record(object):
         if self.scheme in self.default_uri_templates:
             cfg = self.default_uri_templates[self.scheme]
             self.base_uri = cfg['uri']
-            self.scheme_uri = self.uri('scheme', 'edition')
-            self.table_scheme_uri = self.uri('table', self.table)
+            edition = 'edition' if self.scheme_edition is not None else ''
+            self.scheme_uri = self.uri('scheme', edition)
+            table = self.table if self.table is not None else ''
+            self.table_scheme_uri = self.uri('table', table)
 
         # 253 : Complex See Reference (R)
         # Example:
@@ -424,9 +429,7 @@ class Record(object):
         buf = ''
         is_top_concept = True
 
-        parts = [
-
-        ]
+        parts = []
 
         for sf in element.all('mx:subfield'):
             code = sf.get('code')
@@ -620,7 +623,7 @@ class UnknownClassificationScheme(RuntimeError):
 
 
 def process_record(graph, rec, **kwargs):
-    # Parse a single MARC21 classification record
+    """Convert a single MARC21 classification record to RDF."""
 
     rec = Record(rec, default_uri_templates)
 
@@ -716,7 +719,7 @@ def main():
     t0 = time.time()
     for record in get_records(in_file):
         try:
-            res = process_record(graph, record, **options)
+            process_record(graph, record, **options)
         except InvalidRecordError as e:
             # logger.debug('Ignoring invalid record: %s', e)
             pass  # ignore

--- a/mc2skos/mc2skos.py
+++ b/mc2skos/mc2skos.py
@@ -11,8 +11,8 @@ import time
 from lxml import etree
 from iso639 import languages
 import argparse
-from rdflib.namespace import OWL, RDF, RDFS, SKOS, Namespace
-from rdflib import URIRef, RDFS, Literal, Graph, BNode
+from rdflib.namespace import OWL, RDF, SKOS, Namespace
+from rdflib import URIRef, Literal, Graph, BNode
 from otsrdflib import OrderedTurtleSerializer
 
 import logging
@@ -31,8 +31,6 @@ logger.addHandler(console_handler)
 
 WD = Namespace('http://data.ub.uio.no/webdewey-terms#')
 MADS = Namespace('http://www.loc.gov/mads/rdf/v1#')
-
-counts = {}
 
 default_uri_templates = {
     "ddc": {
@@ -618,10 +616,6 @@ class Record(object):
             graph.add((b1, RDF.rest, RDF.nil))
 
 
-class UnknownClassificationScheme(RuntimeError):
-    pass
-
-
 def process_record(graph, rec, **kwargs):
     """Convert a single MARC21 classification record to RDF."""
 
@@ -716,7 +710,6 @@ def main():
     }
 
     n = 0
-    t0 = time.time()
     for record in get_records(in_file):
         try:
             process_record(graph, record, **options)

--- a/tests/test_process_examples.py
+++ b/tests/test_process_examples.py
@@ -2,6 +2,7 @@
 import unittest
 import pytest
 import os
+import sys
 import glob
 import re
 from lxml import etree
@@ -10,35 +11,57 @@ from rdflib.namespace import RDF, SKOS, Namespace
 from rdflib import URIRef, Literal, Graph
 
 
-def get_records(filename):
-    for _, record in etree.iterparse(filename, tag='{http://www.loc.gov/MARC21/slim}record'):
-        yield record
-        record.clear()
+class MarcFile:
+    record_tag = '{http://www.loc.gov/MARC21/slim}record'
+
+    def __init__(self, name):
+        self.name = name
+
+    def records(self):
+        for _, record in etree.iterparse(self.name, tag=MarcFile.record_tag):
+            yield record
+            record.clear()
+
+    def processed_records(self, **options):
+        graph = Graph()
+        for record in self.records():
+            process_record(graph, record, **options)
+        return graph
 
 
-@pytest.fixture(params=glob.glob('examples/*.xml'))
-def marc_file(request):
-    return request.param
+def examples(prefix, pattern):
+
+    pattern = '^(examples/%s%s)\.xml$' % (prefix, pattern)
+    files = glob.glob('examples/%s*.xml' % prefix)
+
+    return [(MarcFile(f), re.match(pattern, f)) for f in files]
 
 
+def check_rdf(graph, expect, rdf_file):
+    graph.namespace_manager.bind('skos', URIRef('http://www.w3.org/2004/02/skos/core#'))
+
+    if os.path.isfile(rdf_file):
+        expect.parse(rdf_file, format='turtle')
+    elif len(graph) > 0:
+        graph.serialize(destination=rdf_file, format='turtle')
+
+    # graph.serialize(destination=sys.stdout, format='turtle')
+
+    for triple in expect:
+        assert triple in graph
+
+
+@pytest.mark.parametrize('marc_file',
+                         examples('ddc',
+                                  '(?P<edition>\d{2})(?P<lang>[a-z]+)-'
+                                  '(?P<notation>((?P<table>\d+)--)?[\d.]+-?[\d.]*)'))
 def test_ddc_example(marc_file):
+    marc, match = tuple(marc_file)
 
-    graph = Graph()
-    nsmap = {'mx': 'http://www.loc.gov/MARC21/slim'}
-
-    match = re.match('^(?P<name>examples/ddc(?P<edition>\d{2})(?P<lang>[a-z]+)-(?P<notation>((?P<table>\d+)--)?[\d.]+-?[\d.]*))\.xml$', marc_file)
-    assert match is not None
-
-    name = match.group('name')
     edition = match.group('edition')
     notation = match.group('notation')
     table = match.group('table')
-
-    rdf_file = marc_file[:marc_file.rindex('.')] + '.ttl'
-
-    graph = Graph()
-    for record in get_records(marc_file):
-        process_record(graph, record)
+    rdf_file = match.group(1) + '.ttl'
 
     expect = Graph()
     uri = URIRef(u'http://dewey.info/class/' + notation + '/e' + edition + '/')
@@ -47,14 +70,24 @@ def test_ddc_example(marc_file):
         notation = "T" + notation
     expect.add((uri, SKOS.notation, Literal(notation)))
 
-    if os.path.isfile(rdf_file):
-        expect.parse(rdf_file, format='turtle')
-    elif len(graph) > 0:
-        graph.namespace_manager.bind('skos', URIRef('http://www.w3.org/2004/02/skos/core#'))
-        graph.serialize(destination=rdf_file, format='turtle')
+    graph = marc.processed_records()
+    check_rdf(graph, expect, rdf_file)
 
-    for triple in expect:
-        assert triple in graph
+
+@pytest.mark.parametrize('marc_file', examples('bk', '-(?P<notation>[0-9.]+)'))
+def test_bk_example(marc_file):
+    marc, match = tuple(marc_file)
+
+    notation = match.group('notation')
+    rdf_file = match.group(1) + '.ttl'
+
+    expect = Graph()
+    uri = URIRef(u'http://uri.gbv.de/terminology/bk/' + notation)
+    expect.add((uri, RDF.type, SKOS.Concept))
+
+    graph = marc.processed_records(include_indexterms=True)
+    check_rdf(graph, expect, rdf_file)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This commit adds another use case to DDC with the Basisklassifikation (BK). A minor change in creation of URI template was needed for classifications that lack edition and/or tables.