### PR TITLE
Include JSKOS context document

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include mc2skos/jskos-context.json

--- a/setup.py
+++ b/setup.py
@@ -47,5 +47,9 @@ setup(name='mc2skos',
       setup_requires=['rdflib', 'pytest-runner>=2.9'],
       tests_require=['pytest', 'pytest-pep8', 'pytest-cov'],
       packages=['mc2skos'],
-      entry_points={'console_scripts': ['mc2skos=mc2skos.mc2skos:main']}
+      entry_points={'console_scripts': ['mc2skos=mc2skos.mc2skos:main']},
+      package_data={
+          'mc2skos': ['jskos-context.json']
+      },
+      include_package_data=True
       )


### PR DESCRIPTION
The asset `jskos-context.json` required for JSKOS was not included in the released egg.