### PR TITLE
Map 684 Auxiliary Instruction Note to skos:editorialNote

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -134,6 +134,7 @@ MARC21XML                                                    RDF
 ``353`` Complex See Also Reference                          ``skos:editorialNote``
 ``680`` Scope Note                                          ``skos:scopeNote``
 ``683`` Application Instruction Note                        ``skos:editorialNote``
+``684`` Auxiliary Instruction Note                          ``skos:editorialNote``
 ``685`` History Note                                        ``skos:historyNote``
 ``700`` Index Term-Personal Name                            ``skos:altLabel``
 ``710`` Index Term-Corporate Name                           ``skos:altLabel``

--- a/mc2skos/record.py
+++ b/mc2skos/record.py
@@ -387,6 +387,7 @@ class ClassificationRecord(Record):
         for entry in self.record.all('mx:datafield[@tag="685"]'):
             self.historyNote.append(entry.stringify())  # Constants.HISTORY_NOTE
 
+        # 684 : Auxiliary Instruction Note
         # 694 : ??? Note : Non-standard code for 684 'Auxiliary Instruction Note' ??
         # Example:
         #   <mx:datafield tag="694" ind2=" " ind1=" ">
@@ -395,7 +396,7 @@ class ClassificationRecord(Record):
         #     <mx:subfield code="9">ess=nml</mx:subfield>
         #   </mx:datafield>
         #
-        for entry in self.record.all('mx:datafield[@tag="694"]'):
+        for entry in self.record.all('mx:datafield[@tag="684" or @tag="694"]'):
             self.editorialNote.append(entry.stringify())
 
         # 7XX Index terms


### PR DESCRIPTION
MARC field `684` is used for instance in RVK data.