### PR TITLE
Fix 153 processing with multiple $e

### DIFF
--- a/examples/rvk.ttl
+++ b/examples/rvk.ttl
@@ -1,0 +1,38 @@
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix mads: <http://www.loc.gov/mads/rdf/v1#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix wd: <http://data.ub.uio.no/webdewey-terms#> .
+@prefix xml: <http://www.w3.org/XML/1998/namespace> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+# RVK has no official URIs yet. Use example.org for testing
+
+<http://example.org/rvk/A> a skos:Concept ;
+    dcterms:created "2012-07-05"^^xsd:date ;
+    dcterms:identifier "1:" ;
+    dcterms:modified "2017-09-12"^^xsd:date ;
+    skos:notation "A" ;
+    skos:prefLabel "Allgemeines"@de ;
+    skos:topConceptOf <http://example.org/rvk> .
+
+<http://example.org/rvk/AA> a skos:Concept ;
+    dcterms:created "2012-07-05"^^xsd:date ;
+    dcterms:identifier "2:" ;
+    dcterms:modified "2017-09-12"^^xsd:date ;
+    skos:broader <http://example.org/rvk/A> ;
+    skos:inScheme <http://example.org/rvk> ;
+    skos:notation "AA" ;
+    skos:prefLabel "Bibliographien der Bibliographien, Universalbibliographien, Bibliothekskataloge, Nationalbibliographien"@de .
+
+<http://example.org/rvk/AA-09900> a skos:Concept ;
+    dcterms:created "2012-07-05"^^xsd:date ;
+    dcterms:identifier "3:" ;
+    dcterms:modified "2017-09-12"^^xsd:date ;
+    skos:broader <http://example.org/rvk/AA> ;
+    skos:editorialNote "Erläuterungen zur Notationsvergabe s. RVK-Online - Nutzunghinweise"@de ;
+    skos:inScheme <http://example.org/rvk> ;
+    skos:notation "AA 09900" ;
+    skos:prefLabel "Bibliographische Zeitschriften"@de .

--- a/examples/rvk.xml
+++ b/examples/rvk.xml
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<collection xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.loc.gov/MARC21/slim" xsi:schemaLocation="http://www.loc.gov/MARC21/slim http://www.loc.gov/standards/marcxml/schema/MARC21slim.xsd">
+  <record>
+    <leader>     nw  a22     o  4500</leader>
+    <controlfield tag="001">1:</controlfield>
+    <controlfield tag="003">DE-625</controlfield>
+    <controlfield tag="005">201709121656.1</controlfield>
+    <controlfield tag="008">120705an|aznnaabbn           | anc    |c</controlfield>
+    <datafield tag="040" ind1=" " ind2=" ">
+      <subfield code="a">DE-625</subfield>
+      <subfield code="b">ger</subfield>
+      <subfield code="c">DE-625</subfield>
+      <subfield code="d">DE-625</subfield>
+    </datafield>
+    <datafield tag="084" ind1="0" ind2=" ">
+      <subfield code="a">rvk</subfield>
+    </datafield>
+    <datafield tag="153" ind1=" " ind2=" ">
+      <subfield code="a">A</subfield>
+      <subfield code="j">Allgemeines</subfield>
+    </datafield>
+  </record>
+  <record>
+    <leader>     nw  a22     o  4500</leader>
+    <controlfield tag="001">2:</controlfield>
+    <controlfield tag="003">DE-625</controlfield>
+    <controlfield tag="005">201709121656.1</controlfield>
+    <controlfield tag="008">120705an|aznnaabbn           | anc    |c</controlfield>
+    <datafield tag="040" ind1=" " ind2=" ">
+      <subfield code="a">DE-625</subfield>
+      <subfield code="b">ger</subfield>
+      <subfield code="c">DE-625</subfield>
+      <subfield code="d">DE-625</subfield>
+    </datafield>
+    <datafield tag="084" ind1="0" ind2=" ">
+      <subfield code="a">rvk</subfield>
+    </datafield>
+    <datafield tag="153" ind1=" " ind2=" ">
+      <subfield code="a">AA</subfield>
+      <subfield code="j">Bibliographien der Bibliographien, Universalbibliographien, Bibliothekskataloge, Nationalbibliographien</subfield>
+      <subfield code="e">A</subfield>
+      <subfield code="h">Allgemeines</subfield>
+    </datafield>
+  </record>
+  <record>
+    <leader>     nw  a22     o  4500</leader>
+    <controlfield tag="001">3:</controlfield>
+    <controlfield tag="003">DE-625</controlfield>
+    <controlfield tag="005">201709121656.1</controlfield>
+    <controlfield tag="008">120705an|aznnaabbn           | anc    |c</controlfield>
+    <datafield tag="040" ind1=" " ind2=" ">
+      <subfield code="a">DE-625</subfield>
+      <subfield code="b">ger</subfield>
+      <subfield code="c">DE-625</subfield>
+      <subfield code="d">DE-625</subfield>
+    </datafield>
+    <datafield tag="084" ind1="0" ind2=" ">
+      <subfield code="a">rvk</subfield>
+    </datafield>
+    <datafield tag="153" ind1=" " ind2=" ">
+      <subfield code="a">AA 09900</subfield>
+      <subfield code="j">Bibliographische Zeitschriften</subfield>
+      <subfield code="e">A</subfield>
+      <subfield code="h">Allgemeines</subfield>
+      <subfield code="e">AA</subfield>
+      <subfield code="h">Bibliographien der Bibliographien, Universalbibliographien, Bibliothekskataloge, Nationalbibliographien</subfield>
+    </datafield>
+    <datafield tag="684" ind1="1" ind2=" ">
+      <subfield code="i">Erläuterungen zur Notationsvergabe s. RVK-Online - Nutzunghinweise</subfield>
+    </datafield>
+    <datafield tag="750" ind1="1" ind2="7">
+      <subfield code="0">(DE-588)4006432-3</subfield>
+      <subfield code="a">Bibliografie</subfield>
+      <subfield code="2">gnd</subfield>
+    </datafield>
+    <datafield tag="750" ind1="1" ind2="7">
+      <subfield code="0">(DE-588)4067488-5</subfield>
+      <subfield code="a">Zeitschrift</subfield>
+      <subfield code="2">gnd</subfield>
+    </datafield>
+  </record>
+</collection>

--- a/mc2skos/record.py
+++ b/mc2skos/record.py
@@ -503,20 +503,26 @@ class ClassificationRecord(Record):
         notation = None
         parent_notation = None
         buf = ''
+        zbuf = ''
         is_top_concept = True
 
         parts = []
 
-        for sf in element.all('mx:subfield'):
+        subfields = [sf for sf in element.all('mx:subfield')]
+        # logger.warning( [sf for sf in subfields if sf.get('code') == 'e'].count() )
+
+        for sf in subfields:
             code = sf.get('code')
             val = sf.text()
 
             if code == 'z':
                 if buf != '':
-                    parts.append(buf)
+                    parts.append(zbuf + buf)
                 if len(parts) == 0:
                     table = val
-                buf = val + '--'
+                zbuf = val + '--'
+                buf = ''
+                # buf = val + '--'
 
             elif code == 'a':
                 buf += val
@@ -527,9 +533,9 @@ class ClassificationRecord(Record):
             elif code == 'e':
                 if len(parts) == 0:
                     # not a table number
-                    parts.append(buf)
+                    parts.append(zbuf + buf)
                     buf = ''
-                buf += val
+                buf = val
             elif code == 'f':
                 buf += '-' + val
 
@@ -541,7 +547,7 @@ class ClassificationRecord(Record):
                     buf += ':{0};'.format(val)
 
         if buf != '':
-            parts.append(buf)
+            parts.append(zbuf + buf)
 
         notation = parts[0]
         if len(parts) != 1:

--- a/tests/test_process_examples.py
+++ b/tests/test_process_examples.py
@@ -84,6 +84,18 @@ def test_bk_asb_example(marc, match):
 
     check_processing(marc, expect, include_altlabels=True)
 
+
+@pytest.mark.parametrize('marc,match', examples('rvk'))
+def test_rvk_example(marc, match):
+
+    options = {
+        'include_altlabels': True,
+        'scheme_uri': 'http://example.org/rvk',
+        'base_uri': 'http://example.org/rvk/{object}'
+    }
+
+    check_processing(marc, Graph(), **options)
+
 vocabularies = {
     'lcsh': 'http://id.loc.gov/authorities/subjects/',
     'noubomn': 'http://data.ub.uio.no/realfagstermer/',


### PR DESCRIPTION
In MARC field 153 with multiple `$e` all its values were concatenated instead of taking the last one only, so the URI for `skos:broader` was wrong.  Test case `rvk.xml` contains an example starting at line 60. 