### PR TITLE
Support mapping from classification records

### DIFF
--- a/examples/rvk-gnd-mapping.ttl
+++ b/examples/rvk-gnd-mapping.ttl
@@ -1,0 +1,22 @@
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix xml: <http://www.w3.org/XML/1998/namespace> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+<http://rvk.uni-regensburg.de/nt/AA_09900> a skos:Concept ;
+    dcterms:created "2012-07-05"^^xsd:date ;
+    dcterms:identifier "3:" ;
+    dcterms:modified "2018-03-16"^^xsd:date ;
+    skos:altLabel "Bibliografie"@de,
+        "Zeitschrift"@de ;
+    skos:broader <http://rvk.uni-regensburg.de/nt/AA> ;
+    skos:closeMatch <http://d-nb.info/gnd/4006432-3>,
+        <http://d-nb.info/gnd/4067488-5> ;
+    skos:editorialNote "Erläuterungen zur Notationsvergabe s. RVK-Online - Nutzunghinweise"@de ;
+    skos:inScheme <http://rvk.uni-regensburg.de/nt/> ;
+    skos:notation "AA 09900" ;
+    skos:prefLabel "Bibliographische Zeitschriften"@de .
+

--- a/examples/rvk-gnd-mapping.xml
+++ b/examples/rvk-gnd-mapping.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<collection 
+xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
+ xsi:schemaLocation="http://www.loc.gov/MARC21/slim http://www.loc.gov/standards/marcxml/schema/MARC21slim.xsd" 
+xmlns="http://www.loc.gov/MARC21/slim">
+<record>
+<leader>     nw  a22     o  4500</leader>
+<controlfield tag="001">3:</controlfield>
+<controlfield tag="003">DE-625</controlfield>
+<controlfield tag="005">201803160839.2</controlfield>
+<controlfield tag="008">120705an|aznnaabbn           | anc    |c</controlfield>
+<datafield tag="040" ind1=" " ind2=" ">
+<subfield code="a">DE-625</subfield>
+<subfield code="b">ger</subfield>
+<subfield code="c">DE-625</subfield>
+<subfield code="d">DE-625</subfield>
+</datafield>
+<datafield tag="084" ind1="0" ind2=" ">
+<subfield code="a">rvk</subfield>
+</datafield>
+<datafield tag="153" ind1=" " ind2=" ">
+<subfield code="a">AA 09900</subfield>
+<subfield code="j">Bibliographische Zeitschriften</subfield>
+<subfield code="e">A</subfield>
+<subfield code="h">Allgemeines</subfield>
+<subfield code="e">AA</subfield>
+<subfield code="h">Bibliographien der Bibliographien, Universalbibliographien, Bibliothekskataloge, Nationalbibliographien</subfield>
+</datafield>
+<datafield tag="684" ind1="1" ind2=" ">
+<subfield code="i">Erläuterungen zur Notationsvergabe s. RVK-Online - Nutzunghinweise</subfield>
+</datafield>
+<datafield tag="750" ind1="1" ind2="7">
+<subfield code="0">(DE-588)4006432-3</subfield>
+<subfield code="a">Bibliografie</subfield>
+<subfield code="2">gnd</subfield>
+</datafield>
+<datafield tag="750" ind1="1" ind2="7">
+<subfield code="0">(DE-588)4067488-5</subfield>
+<subfield code="a">Zeitschrift</subfield>
+<subfield code="2">gnd</subfield>
+</datafield>
+</record>
+</collection>

--- a/mc2skos/vocabularies.yml
+++ b/mc2skos/vocabularies.yml
@@ -30,3 +30,10 @@ subject_schemes:
     noubomr:
         concept: http://data.ub.uio.no/mrtermer/c{control_number[3:]}
         scheme: http://data.ub.uio.no/mrtermer/
+    gnd:
+        concept: http://d-nb.info/gnd/{control_number}
+        scheme: http://d-nb.info/gnd/
+    ddcri:
+        scheme: http://id.loc.gov/vocabulary/subjectSchemes/ddcri
+    TESA:
+        cheme: http://lod.nal.usda.gov/nalt/

--- a/test/test_process_examples.py
+++ b/test/test_process_examples.py
@@ -70,7 +70,7 @@ def test_bk_asb_example(marc, match):
     check_processing(marc, expect, include_altlabels=True)
 
 
-@pytest.mark.parametrize('marc,match', examples('rvk'))
+@pytest.mark.parametrize('marc,match', examples('rvk(-.*)?'))
 def test_rvk_example(marc, match):
 
     options = {


### PR DESCRIPTION
Move code for extraction of mappings from 7XX from authority records to
all types of records. This required addition of vocabulary codes to
`mc2skos/vocabularies.yml`. Tested with an RVK record mapped to GND.

This fixes feature request #51.