### PR TITLE
Handle cases when subfield 4 is missing

### DIFF
--- a/mc2skos/mc2skos.py
+++ b/mc2skos/mc2skos.py
@@ -48,6 +48,17 @@ MADS = Namespace('http://www.loc.gov/mads/rdf/v1#')
 
 
 def add_record_to_graph(graph, record, options):
+
+    # custom language settings for the National Library of Latvia authority file
+
+    if options.get('nll_lang'):
+
+        #  - no default language (because of labels can be in multiple languages)
+        record.lang = None
+        #  - except for prefLabels (which are in Latvian)
+        record.prefLang = "lv"
+
+
     # Add record to graph
 
     # logger.debug('Adding: %s', record.uri)
@@ -85,13 +96,13 @@ def add_record_to_graph(graph, record, options):
 
     # Add caption as skos:prefLabel
     if record.prefLabel:
-        graph.add((record_uri, SKOS.prefLabel, Literal(record.prefLabel, lang=record.lang)))
+        graph.add((record_uri, SKOS.prefLabel, Literal(record.prefLabel, lang=record.prefLang)))
     elif options.get('include_webdewey') and len(record.altLabel) != 0:
         # If the --webdewey flag is set, we will use the first index term as prefLabel
         caption = record.altLabel.pop(0)['term']
         if len(record.altLabel) != 0:
             caption = caption + ', …'
-        graph.add((record_uri, SKOS.prefLabel, Literal(caption, lang=record.lang)))
+        graph.add((record_uri, SKOS.prefLabel, Literal(caption, lang=record.prefLang)))
 
     # Add index terms as skos:altLabel
     if options.get('include_altlabels'):
@@ -247,6 +258,9 @@ def main():
     parser.add_argument('-l', '--list-schemes', dest='list_schemes', action='store_true',
                         help='List default concept schemes.')
 
+    parser.add_argument('--nll-lang', dest='nll_lang', action='store_true',
+                        help='Set langugage tags specific to the NLL authority file.')
+
     args = parser.parse_args()
 
     if args.notes:
@@ -311,7 +325,8 @@ def main():
         'skip_authority': args.skip_authority,
         'expand': args.expand,
         'skosify': args.skosify,
-        'vocabularies': vocabularies
+        'vocabularies': vocabularies,
+        'nll_lang': args.nll_lang
     }
 
     marc = MarcFileReader(args.infile)

--- a/mc2skos/record.py
+++ b/mc2skos/record.py
@@ -41,6 +41,7 @@ class Record(object):
         self.created = None
         self.modified = None
         self.lang = None
+        self.prefLang = None
         self.prefLabel = None
         self.altLabel = []
         self.definition = []
@@ -157,6 +158,7 @@ class Record(object):
         # 040: Record Source
         lang = self.record.text('mx:datafield[@tag="040"]/mx:subfield[@code="b"]') or 'eng'
         self.lang = languages.get(part2b=lang).part1
+        self.prefLang = self.lang
 
     def is_public(self):
         return True

--- a/mc2skos/record.py
+++ b/mc2skos/record.py
@@ -688,14 +688,14 @@ class AuthorityRecord(Record):
                         relation = SKOS.broader
                     elif sf_w == 'h':
                         relation = SKOS.narrower
-                    elif sf_w == 'r' and is_uri(sf_4):
+                    elif sf_w == 'r' and sf_4 is not None and is_uri(sf_4):
                         relation = URIRef(sf_4)
                     else:
                         relation = SKOS.related
 
                     if is_uri(local_id):
                         self.relations.append({
-                            'uri': uri,
+                            'uri': local_id,
                             'relation': relation,
                         })
                     else:

--- a/mc2skos/record.py
+++ b/mc2skos/record.py
@@ -209,7 +209,7 @@ class Record(object):
                             'RM': SKOS.relatedMatch,
                         }.get(sf.text())  # None if no match
 
-                elif sf.get('code') == '0':
+                elif sf.get('code') == '0' or sf.get('code') == '1':
                     # Note: Default value might change in the future
                     relation = relation if relation else SKOS.closeMatch
 

--- a/mc2skos/vocabularies.yml
+++ b/mc2skos/vocabularies.yml
@@ -30,6 +30,9 @@ subject_schemes:
     noubomr:
         concept: http://data.ub.uio.no/mrtermer/c{control_number[3:]}
         scheme: http://data.ub.uio.no/mrtermer/
+    nll:
+        concept: http://dati.lnb.lv/skos/{control_number}
+        scheme: http://dati.lnb.lv/skos/
     gnd:
         concept: http://d-nb.info/gnd/{control_number}
         scheme: http://d-nb.info/gnd/


### PR DESCRIPTION
If subfield $4 is missing when mapping 5XX record relations the program crashes with an AttributeError (when sf_4 is None).

This pull request gets rid of this AttributeError by checking for None.

See also: https://github.com/scriptotek/mc2skos/issues/68

